### PR TITLE
Add dataset-first assay/QC schema and path-only video support

### DIFF
--- a/docs/dev/MOSEQ2_WORKSPACE_IMPORT_PLAN.md
+++ b/docs/dev/MOSEQ2_WORKSPACE_IMPORT_PLAN.md
@@ -1,0 +1,324 @@
+# MoSeq2 Workspace → MUS1 DB Import Plan (branch: `feature/moseq2-workspace-import`)
+
+## Goal (this branch)
+
+Create a **first-class import path** from this MoSeq2 analysis workspace (`moseq2_workspace/`) into a MUS1 project database (`mus1.db`) so that:
+
+- MUS1 can **represent sessions/recordings** as `subjects` + `experiments` + `videos` (existing tables).
+- The MoSeq2 workspace artifacts (MoSeq2 `.h5` results, YAMLs, metadata JSON, syllable UUID maps, arena ROI JSONs, downstream stats outputs, **rotarod rerun tables**, and **KPMS trimmed-30s reruns**) become **queryable DB records** with **provenance**, without requiring ingesting huge arrays into SQL.
+- The resulting DB schema stays **portable** (SQLite now; later Postgres on Chinook).
+
+Hard constraint for Chinook storage:
+
+- **Do not copy videos** into a MUS1 project folder for this dataset. Persist **absolute file locations** (and optionally content hashes) into the DB. This keeps disk usage bounded under the Chinook quota.
+
+This document is planning + orientation only. Implementation should follow MUS1’s existing service/repository layering (see `docs/dev/ARCHITECTURE_CURRENT.md`).
+
+## Current state (what exists today)
+
+### MUS1 core data model (already implemented)
+
+MUS1 already has project-local tables for:
+
+- `subjects` (`SubjectModel`)
+- `experiments` (`ExperimentModel`) with `processing_stage`
+- `videos` (`VideoModel`) with `(path UNIQUE, hash NOT NULL)`
+- `experiment_videos` many-to-many association
+- plus lab/user tables that are orthogonal to this import
+
+These live in:
+
+- `src/mus1/core/schema.py`
+- `src/mus1/core/repository.py`
+- `src/mus1/core/project_manager_clean.py`
+
+### MoSeq2 workspace “index of record”
+
+The most useful “single source of truth” for import is:
+
+- `ml_tracking_metadata_model/index/session_index_filtered.csv`
+  - Contains (at least): `session_id`, `task`, `subject_id`, `recording_date`, `birthdate`, `sex`, `genotype`, `treatment`, `arena_bucket`
+  - Contains paths to key artifacts such as:
+    - `moseq2_results_h5_path` (aggregate results `.h5`)
+    - `moseq2_results_yaml_path` (proc `results_00.yaml`)
+    - `moseq2_metadata_path` (`metadata.json`)
+    - `moseq2_identifier_path` (a MUS1 identifier file already exists in this workspace)
+    - `syllable_uuid` (UUID for this session) + `syllable_stats_path` (CSV)
+- `ml_tracking_metadata_model/index/syllable_uuid_map.csv`
+  - Maps `uuid → h5_path/session_name/start_time/subject_name/group`
+
+Critical workflow note from this workspace:
+
+- `session_index_filtered.csv` is not “hand-edited”; it is the output of a multi-source build + filter pipeline:
+  - built by `ml_tracking_metadata_model/scripts/build_session_index.py` (joins rosters + MP4 identifiers + KPMS recordings + MoSeq2 identifiers)
+  - filtered by `ml_tracking_metadata_model/scripts/filter_session_index.py` (enforces required labels/paths per task; de-dups `session_id`)
+- Therefore MUS1 should **consume the compiled index as the data contract**, and record **its provenance** (which index file, which workspace root, and ideally the `integrity_report.txt` summary) rather than re-implementing indexing heuristics inside MUS1.
+
+### Subject rosters (additional sources of truth; required)
+
+These already exist and should be treated as independent, partially-trustworthy sources:
+
+- `resources/metadata/subjects_roster.csv`
+  - Minimal “authoritative” per-subject info (tag, genotype, sex, birthdate, treatment type)
+- `resources/metadata/open_field_roster.cleaned.csv`
+  - Session-level OF info (tag, genotype/sex/birthdate/treatment, test_date, bucket_type, notes)
+
+Plan requirement: before “final DB build”, run integrity checks that **cross-compare multiple sources** (rosters, session indexes, and any identifier JSONs), and record mismatches as structured QC outputs.
+
+### Operational reality: missing/corrupt assets must be first-class
+
+`docs/CURRENT_STATUS.md` shows the real failure modes you already encounter (and work around):
+
+- missing DLC inference outputs for a small subset of recordings
+- corrupted MP4s (e.g. “moov atom not found”)
+- duplicate/archived sessions and repaired identifiers
+
+The MUS1 import must be **tolerant**:
+
+- do not fail the entire import when a subset is missing
+- instead, persist a QC/event record for each missing/corrupt dependency and keep importing the rest
+
+### Rotarod rerun dataset (required)
+
+There is already a cleaned, join-enriched rotarod dataset under:
+
+- `statistics_summaries/rotarod_reanalysis/rotarod_clean.csv` (session-level wide table with QC flags)
+- `statistics_summaries/rotarod_reanalysis/rotarod_sessions_cleaned.csv` (session-level long-ish)
+- `statistics_summaries/rotarod_reanalysis/rotarod_attempts_long_cleaned.csv` (attempt-level long table)
+
+These should be imported as first-class assay data (not just “artifact pointers”).
+
+### KPMS “trimmed 30s” reruns (required)
+
+There are explicit rerun projects that include trimmed video + CSV inputs and a `recordings.csv` index:
+
+- `analysis_keypoint_moseq/_reruns/20260122_trim30s_ezm/metadata/recordings.csv`
+- `analysis_keypoint_moseq/_reruns/20260122_trim30s_nor_nof/metadata/recordings.csv`
+
+These include:
+
+- `input/*.mp4` (trimmed clips; already exist on disk)
+- `input/*.csv` (paired tracking/keypoint inputs)
+- model outputs under `*_kpms_trim30s_20260122_iters100/`
+
+We should index these reruns in the same way we index the baseline KPMS projects, but without copying any video content into a MUS1 project directory.
+
+### Arena annotations + task metrics already exist (workspace side)
+
+Arena annotation produces **versioned per-video JSON files** used by downstream scripts:
+
+- EZM zones:
+  - `resources/arena_zones/ezm_per_video_v2/<video_stem>_ezm_open_closed_v2.json`
+- NOR/NOF object ROIs:
+  - `resources/arena_zones/nor_nof_per_video_v1/<video_stem>_nor_nof_objects_v1.json`
+
+Arena annotation tool and geometry definitions:
+
+- `scripts/arena_annotation/app.py` (Streamlit UI)
+- `scripts/arena_annotation/ezm_geometry.py`
+- `scripts/arena_annotation/nor_nof_geometry.py`
+
+Downstream “stats outputs” currently land as CSVs under `statistics_summaries/...` (e.g. NOR/NOF object-interaction metrics from `scripts/statistics_organized/dlc_nor_nof_object_interactions/compute_nor_nof_object_interactions.py`).
+
+## Proposed branch deliverables (incremental)
+
+### Deliverable A — importer creates core entities and indexes (dataset-first)
+
+Implement a new MUS1 import entrypoint that:
+
+- Reads:
+  - `ml_tracking_metadata_model/index/session_index_filtered.csv`
+  - `ml_tracking_metadata_model/index/syllable_uuid_map.csv` (optional but recommended)
+  - `resources/metadata/subjects_roster.csv`
+  - `resources/metadata/open_field_roster.cleaned.csv`
+  - rotarod reanalysis CSVs under `statistics_summaries/rotarod_reanalysis/`
+  - KPMS trimmed-30s rerun `metadata/recordings.csv` for EZM + NOR/NOF reruns
+- Upserts:
+  - **Subject** per `subject_id` (string)
+    - `sex` from `sex`
+    - `birth_date` from `birthdate`
+    - `individual_genotype` from `genotype`
+    - `individual_treatment` from `treatment`
+  - **Experiment** per `session_id` (string)
+    - `experiment_type` from `task` (e.g. `OF`, `EZM`, `NOR`, `NOF`)
+    - `date_recorded` from `recording_date`
+    - `processing_stage` derived from artifact presence:
+      - baseline: `TRACKED` when `moseq2_results_h5_path` exists
+      - optionally: `INTERPRETED` when downstream metric artifacts are present/imported
+  - **Video** record + **experiment↔video** link when a stable video identifier is present.
+
+Important constraint (current MUS1 schema): `videos.hash` is **NOT NULL** and `videos.path` is **UNIQUE**. The import needs a stable rule:
+
+- Prefer a workspace-provided stable identifier already in the index:
+  - `moseq2_session_name` looks like a stable hex session ID in the CSV.
+- Use `video_path` if present; otherwise store the best available path we have (`moseq2_source_filename` alone is not a full path).
+
+If actual video files are accessible at import time, MUS1 can compute its normal sample hash; but the import should not assume that. For Chinook scale and storage limits, we will primarily store:
+
+- the **absolute path** of each video (original or trimmed rerun path), and
+- a hash only when the file is reachable and hashing is affordable.
+
+Meaningful refinement (recommended schema change):
+
+- For this dataset-first path-only workflow, change MUS1 `videos.hash` to **nullable** and treat it as an optional optimization (dedupe/verification), not a required field.
+- If we later want “stable IDs” independent of path, add a separate `file_locators`/`file_uris` concept rather than overloading `hash`.
+
+### Deliverable B — add queryable “artifact + annotation” tables (recommended)
+
+To support a web app and real querying, avoid storing everything as opaque JSON blobs. Add minimal normalized tables that:
+
+- link artifacts to existing MUS1 entities (`experiments`, optionally `videos`)
+- keep raw payload paths + lightweight parsed metadata + provenance
+
+Proposed new tables (names are suggestions; finalize after inspecting existing patterns and tests):
+
+1) `external_artifacts`
+- `id` (PK)
+- `experiment_id` (FK → `experiments.id`)
+- `kind` (string; e.g. `moseq2_results_h5`, `moseq2_results_yaml`, `moseq2_metadata_json`, `syllable_stats_csv`, `dlc_csv`, `ezm_zone_json_v2`, `nor_nof_objects_json_v1`, `stats_output_csv`)
+- `path` (text)
+- `content_sha256` (nullable; if file reachable)
+- `created_at`
+- `payload_json` (nullable text; used for small JSON payloads like zone JSON)
+- `meta_json` (nullable text; e.g. derived fields like schema version, fps flags, etc.)
+
+2) `moseq_sessions` (optional but useful if we want session-specific fields without abusing experiment notes)
+- `session_id` (PK, FK → `experiments.id` OR standalone + FK)
+- `syllable_uuid` (nullable; UUID from session index)
+- `arena_bucket`, `kpms_recording_id`, `moseq2_session_name`
+- any other stable identifiers we rely on
+
+3) `moseq_syllable_uuid_map` (optional)
+- `uuid` (PK)
+- `group`
+- `h5_path`
+- `session_name`
+- `start_time`
+- `subject_name`
+
+Why these tables:
+- They let us keep **arena ROI JSONs** and **stats outputs** in the DB with a stable link to an `experiment_id`.
+- They are small and portable to Postgres later.
+- They don’t force loading huge `.h5` arrays into SQL.
+
+### Deliverable B1 — QC/event table (small, high leverage)
+
+Add a minimal table to record integrity findings without blocking the import:
+
+- `qc_events`
+  - `id` (PK)
+  - `scope` (e.g. `subject`, `experiment`, `video`, `artifact`)
+  - `subject_id` / `experiment_id` (nullable FKs)
+  - `code` (e.g. `MISSING_DLC_CSV`, `CORRUPT_MP4`, `ROSTER_MISMATCH`, `DUPLICATE_SESSION_ID`)
+  - `details_json`
+  - `created_at`
+
+### Deliverable B2 — assay tables for rotarod and other non-video assays (recommended)
+
+Rotarod should not be “shoehorned” into generic plugin JSON results; it is a structured longitudinal assay with attempts/timepoints.
+
+Two reasonable options:
+
+1) **Dedicated rotarod tables**
+- `rotarod_sessions` (one row per subject×timepoint session)
+- `rotarod_attempts` (one row per attempt within a session)
+
+2) **Generic assay tables**
+- `assay_sessions` (assay_type + subject + date + metadata)
+- `assay_measurements` (assay_session_id + metric_name + value + units + qc flags)
+
+Given your stated direction (“ideal for this dataset rather than legacy MUS1 decisions”), option (2) is more future-proof, but we should implement it only if we’re committing to a dataset-first schema that will become the web app backend.
+
+### Deliverable C — “export workspace to db” workflow
+
+Add a command that produces a portable bundle:
+
+- `mus1.db` (SQLite) + a `manifest.json` of artifact paths and checksums
+- optionally a “copy artifacts into bundle” mode (large; may not be desired)
+
+This aligns with your stated goal: “download the workspace dataset in DB format”.
+
+## Where this logic should live (MUS1-side)
+
+Keep with existing architecture:
+
+- **Parsing/transform**: pure functions (new module, e.g. `src/mus1/core/importers/moseq2_workspace.py`)
+- **DB writes**: go through `ProjectManagerClean` and repositories, or add a focused service that uses `RepositoryFactory`
+- **CLI entrypoint**: add a `typer` subcommand under `src/mus1/core/simple_cli.py`
+
+If we want this import to be “pluggable” (discoverable in GUI), we can also add it as a MUS1 plugin later, but the first pass should be a deterministic CLI import that can be run headless on Chinook.
+
+## Chinook DB hosting + future web app (high-level direction)
+
+### Step 1: Make MUS1 DB backend configurable
+
+Right now `Database` hardcodes a SQLite file URL:
+
+- `create_engine(f"sqlite:///{db_path}")`
+
+For Chinook hosting we’ll need:
+
+- a DB URL configuration mechanism (env var or config key)
+- a migration story (Alembic or equivalent) rather than `create_all()` as the only schema management
+- the schema to remain SQLAlchemy-native and Postgres-compatible (types, indexes, constraints)
+
+### Step 2: Web app architecture (target)
+
+- Backend: FastAPI (or similar) with SQLAlchemy session mgmt, auth, and endpoints that query:
+  - experiments + linked artifacts
+  - arena annotations per video
+  - computed stats tables
+- Frontend: web UI for browsing sessions and viewing annotations/metrics
+
+This branch is not the web app; it is the data foundation to make that feasible.
+
+## Dataset-first schema direction (explicit)
+
+Your stated intent is to **migrate features one at a time** and remove unnecessary MUS1 components, targeting a web UI (Streamlit or otherwise) backed by a Chinook-hosted DB.
+
+That implies a sequencing change:
+
+- Treat the **DB schema + import + QC** as the primary product.
+- Treat the existing MUS1 Qt GUI as non-goal for this branch (and likely removable once the web UI replaces it).
+
+Concretely, for implementation we should prefer:
+
+- A schema that models your dataset explicitly:
+  - subjects (from roster)
+  - sessions/recordings (OF/EZM/NOR/NOF + KPMS reruns + rotarod)
+  - artifacts/annotations (zone JSONs, MoSeq2 outputs, KPMS outputs, stats tables)
+  - QC findings (mismatches across rosters/index/identifiers)
+- A web-facing API/UI layer that queries those tables directly.
+
+## GitHub privacy (repo visibility)
+
+This working copy is connected to the GitHub repo via `origin = https://github.com/llplatil/mus-1.git`.
+
+I can’t switch visibility from here because the GitHub CLI (`gh`) isn’t installed in this environment. The most reliable path is:
+
+- In GitHub UI: repo `Settings → General → (Danger Zone) Change repository visibility → Make private`
+
+If you install `gh` on the machine where you manage repos, the equivalent is:
+
+```bash
+gh repo edit llplatil/mus-1 --visibility private
+```
+
+## Immediate next steps (actionable)
+
+1) Define the **authoritative import inputs**:
+   - `ml_tracking_metadata_model/index/session_index_filtered.csv`
+   - `resources/metadata/subjects_roster.csv`
+   - `resources/metadata/open_field_roster.cleaned.csv`
+   - `statistics_summaries/rotarod_reanalysis/rotarod_clean.csv` (and its long-form companions)
+   - KPMS trimmed reruns:
+     - `analysis_keypoint_moseq/_reruns/20260122_trim30s_ezm/metadata/recordings.csv`
+     - `analysis_keypoint_moseq/_reruns/20260122_trim30s_nor_nof/metadata/recordings.csv`
+   - arena zones directory/directories to include
+   - which `statistics_summaries/...` outputs should be first-class DB tables vs “artifact pointers”
+
+2) Decide the **video identity rule** for MUS1 `videos`:
+   - whether `moseq2_session_name` becomes the canonical `VideoModel.hash` when files aren’t readable
+
+3) Implement Deliverable A (core entity import), then expand to Deliverable B (artifact/annotation tables).
+

--- a/src/mus1/core/importers/__init__.py
+++ b/src/mus1/core/importers/__init__.py
@@ -1,0 +1,1 @@
+"""Importers for various data sources."""

--- a/src/mus1/core/importers/kpms_recordings.py
+++ b/src/mus1/core/importers/kpms_recordings.py
@@ -1,0 +1,288 @@
+"""
+Importer for KPMS recordings metadata CSV files.
+
+Indexes recordings metadata from KPMS rerun CSV files and stores them as
+external artifacts linked to experiments/subjects when possible.
+"""
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from datetime import datetime
+
+from ..repository import RepositoryFactory
+from ..schema import Database
+
+
+def resolve_absolute_path(workspace_root: Path, path_str: str) -> Optional[Path]:
+    """Resolve a relative path to absolute using workspace root."""
+    if not path_str or not path_str.strip():
+        return None
+    
+    path = Path(path_str.strip())
+    
+    # If already absolute, return as-is
+    if path.is_absolute():
+        return path
+    
+    # Otherwise resolve relative to workspace root
+    resolved = workspace_root / path
+    return resolved if resolved.exists() else None
+
+
+def parse_recording_date(recording_id: str) -> Optional[datetime]:
+    """Extract date from recording_id if possible.
+    
+    Examples:
+    - EZM__159_20202312__12.20.2023_EZM_159 -> 2023-12-20
+    - NOF__02.15.2024_159F_FAM -> 2024-02-15
+    """
+    import re
+    
+    # Try MM.DD.YYYY pattern
+    match = re.search(r'(\d{1,2})\.(\d{1,2})\.(\d{4})', recording_id)
+    if match:
+        month, day, year = match.groups()
+        try:
+            return datetime(int(year), int(month), int(day))
+        except ValueError:
+            pass
+    
+    # Try YYYY-MM-DD pattern
+    match = re.search(r'(\d{4})-(\d{1,2})-(\d{1,2})', recording_id)
+    if match:
+        year, month, day = match.groups()
+        try:
+            return datetime(int(year), int(month), int(day))
+        except ValueError:
+            pass
+    
+    return None
+
+
+def find_experiment_by_heuristics(
+    repos: RepositoryFactory,
+    recording_id: str,
+    subject_tag: Optional[str],
+    condition: str,
+    recording_date: Optional[datetime],
+) -> Optional[str]:
+    """Try to find an experiment ID using heuristics.
+    
+    Heuristics:
+    1. Try recording_id as experiment_id directly
+    2. If subject_tag exists, find experiments for that subject matching condition and date
+    3. Return None if no match found
+    """
+    # Try recording_id as experiment ID directly
+    exp = repos.experiments.find_by_id(recording_id)
+    if exp:
+        return exp.id
+    
+    # If we have subject_tag, try to find matching experiments
+    if subject_tag:
+        subject_experiments = repos.experiments.find_by_subject(subject_tag)
+        
+        # Filter by condition (experiment_type)
+        matching = [e for e in subject_experiments if e.experiment_type == condition]
+        
+        # If we have a date, try to match by date (within 1 day tolerance)
+        if recording_date and matching:
+            best_match = None
+            min_diff = None
+            for exp in matching:
+                if exp.date_recorded:
+                    diff = abs((exp.date_recorded - recording_date).days)
+                    if min_diff is None or diff < min_diff:
+                        min_diff = diff
+                        best_match = exp
+            
+            # Accept match if within 1 day
+            if best_match and min_diff is not None and min_diff <= 1:
+                return best_match.id
+        
+        # Otherwise return first matching experiment if any
+        if matching:
+            return matching[0].id
+    
+    return None
+
+
+def find_subject_by_tag(repos: RepositoryFactory, tag: Optional[str]) -> Optional[str]:
+    """Find subject ID by tag."""
+    if not tag:
+        return None
+    
+    # Try tag as subject ID directly
+    subject = repos.subjects.find_by_id(tag)
+    if subject:
+        return subject.id
+    
+    return None
+
+
+def import_kpms_recordings_csv(
+    repos: RepositoryFactory,
+    csv_path: Path,
+    workspace_root: Path,
+    source_name: str,
+) -> Dict[str, int]:
+    """Import recordings from a KPMS recordings CSV file.
+    
+    Args:
+        repos: Repository factory
+        csv_path: Path to the CSV file
+        workspace_root: Root of the workspace (for resolving relative paths)
+        source_name: Name of the source (e.g., "20260122_trim30s_ezm")
+    
+    Returns:
+        Dictionary with counts: artifacts_added, linked_to_experiment, linked_to_subject, unlinked
+    """
+    stats = {
+        "artifacts_added": 0,
+        "linked_to_experiment": 0,
+        "linked_to_subject": 0,
+        "unlinked": 0,
+    }
+    
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+    
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        
+        for row in reader:
+            recording_id = row.get('recording_id', '').strip()
+            if not recording_id:
+                continue
+            
+            # Extract metadata
+            condition = row.get('condition', '').strip()
+            tag = row.get('tag', '').strip()  # Subject tag
+            video_path = row.get('video_path', '').strip()
+            source_video_path = row.get('source_video_path', '').strip()
+            dlc_csv = row.get('dlc_csv', '').strip()
+            trimmed_dlc_csv = row.get('trimmed_dlc_csv', '').strip()
+            
+            # Parse recording date
+            recording_date = parse_recording_date(recording_id)
+            
+            # Try to find linked entities
+            experiment_id = find_experiment_by_heuristics(
+                repos, recording_id, tag, condition, recording_date
+            )
+            subject_id = find_subject_by_tag(repos, tag)
+            
+            # Track linkage status
+            linked_to_exp = experiment_id is not None
+            linked_to_subj = subject_id is not None
+            
+            if linked_to_exp:
+                stats["linked_to_experiment"] += 1
+            if linked_to_subj:
+                stats["linked_to_subject"] += 1
+            if not linked_to_exp and not linked_to_subj:
+                stats["unlinked"] += 1
+            
+            # Store recording metadata as artifact
+            recording_meta = {
+                "source": source_name,
+                "recording_id": recording_id,
+                "condition": condition,
+                "tag": tag,
+                "recording_date": recording_date.isoformat() if recording_date else None,
+                "genotype": row.get('genotype', '').strip(),
+                "sex": row.get('sex', '').strip(),
+                "treatment": row.get('treatment', '').strip(),
+                "birthdate": row.get('birthdate', '').strip(),
+            }
+            
+            # Store recording metadata artifact
+            repos.external_artifacts.add(
+                kind="kpms_recording_metadata",
+                path=str(csv_path),
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                payload_json=json.dumps(recording_meta),
+                meta={
+                    "source_file": str(csv_path),
+                    "source_name": source_name,
+                    "row_index": reader.line_num - 1,  # Approximate
+                },
+            )
+            stats["artifacts_added"] += 1
+            
+            # Store video paths as artifacts
+            paths_to_store = [
+                ("kpms_video_path", video_path),
+                ("kpms_source_video_path", source_video_path),
+                ("kpms_dlc_csv", dlc_csv),
+                ("kpms_trimmed_dlc_csv", trimmed_dlc_csv),
+            ]
+            
+            for kind, path_str in paths_to_store:
+                if not path_str:
+                    continue
+                
+                abs_path = resolve_absolute_path(workspace_root, path_str)
+                if abs_path:
+                    repos.external_artifacts.add(
+                        kind=kind,
+                        path=str(abs_path),
+                        subject_id=subject_id,
+                        experiment_id=experiment_id,
+                        meta={
+                            "source": source_name,
+                            "recording_id": recording_id,
+                            "original_path": path_str,
+                        },
+                    )
+                    stats["artifacts_added"] += 1
+    
+    return stats
+
+
+def import_kpms_recordings(
+    db_path: Path,
+    csv_paths: List[Path],
+    workspace_root: Path,
+) -> Dict[str, any]:
+    """Import recordings from multiple CSV files.
+    
+    Args:
+        db_path: Path to the MUS1 database
+        csv_paths: List of CSV file paths to import
+        workspace_root: Root of the workspace
+    
+    Returns:
+        Dictionary with import statistics
+    """
+    db = Database(str(db_path))
+    db.create_tables()
+    repos = RepositoryFactory(db)
+    
+    all_stats = {
+        "total_artifacts": 0,
+        "total_linked_to_experiment": 0,
+        "total_linked_to_subject": 0,
+        "total_unlinked": 0,
+        "sources": {},
+    }
+    
+    for csv_path in csv_paths:
+        # Extract source name from path
+        # e.g., .../20260122_trim30s_ezm/metadata/recordings.csv -> 20260122_trim30s_ezm
+        source_name = csv_path.parent.parent.name if csv_path.name == "recordings.csv" else csv_path.stem
+        
+        try:
+            stats = import_kpms_recordings_csv(repos, csv_path, workspace_root, source_name)
+            all_stats["total_artifacts"] += stats["artifacts_added"]
+            all_stats["total_linked_to_experiment"] += stats["linked_to_experiment"]
+            all_stats["total_linked_to_subject"] += stats["linked_to_subject"]
+            all_stats["total_unlinked"] += stats["unlinked"]
+            all_stats["sources"][source_name] = stats
+        except Exception as e:
+            all_stats["sources"][source_name] = {"error": str(e)}
+    
+    return all_stats

--- a/src/mus1/core/importers/moseq2_workspace.py
+++ b/src/mus1/core/importers/moseq2_workspace.py
@@ -1,0 +1,253 @@
+"""
+MoSeq2 workspace importer.
+
+Reads session_index_filtered.csv and imports subjects, experiments, external artifacts,
+and QC events into the MUS1 repository.
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Any, Optional
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import pandas as pd
+
+from ..repository import RepositoryFactory
+from ..metadata import Subject, Experiment, VideoFile, Sex, ProcessingStage, SubjectDesignation
+
+
+@dataclass
+class ImportStats:
+    """Statistics from an import operation."""
+    rows_total: int = 0
+    subjects_upserted: int = 0
+    experiments_upserted: int = 0
+    videos_upserted: int = 0
+    artifacts_added: int = 0
+    qc_events_added: int = 0
+
+
+def _as_path(value: Any) -> Optional[Path]:
+    """Convert a value to a Path if it's a non-empty string, otherwise None."""
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    return Path(value)
+
+
+def _resolve_path(path: Path, workspace_root: Path) -> Path:
+    """Resolve a path to absolute, preferring absolute paths when possible."""
+    if path.is_absolute():
+        return path
+    # Try relative to workspace_root
+    resolved = workspace_root / path
+    if resolved.exists():
+        return resolved.resolve()
+    # Return as-is if it doesn't exist (will be caught by QC check)
+    return path
+
+
+def _parse_date(date_str: Any) -> Optional[datetime]:
+    """Parse a date string to datetime."""
+    if not date_str or pd.isna(date_str):
+        return None
+    if isinstance(date_str, datetime):
+        return date_str
+    if isinstance(date_str, str):
+        date_str = date_str.strip()
+        if not date_str:
+            return None
+        try:
+            return datetime.fromisoformat(date_str)
+        except ValueError:
+            try:
+                return datetime.strptime(date_str, "%Y-%m-%d")
+            except ValueError:
+                return None
+    return None
+
+
+def _parse_sex(sex_str: Any) -> Sex:
+    """Parse sex string to Sex enum."""
+    if not sex_str or pd.isna(sex_str):
+        return Sex.UNKNOWN
+    sex_str = str(sex_str).strip().upper()
+    if sex_str == "M":
+        return Sex.MALE
+    elif sex_str == "F":
+        return Sex.FEMALE
+    else:
+        return Sex.UNKNOWN
+
+
+def import_session_index(
+    repos: RepositoryFactory,
+    *,
+    workspace_root: Path,
+    session_index_csv: Path,
+    check_paths_exist: bool = True,
+) -> ImportStats:
+    """
+    Import MoSeq2 workspace session index CSV into MUS1 repository.
+
+    Args:
+        repos: Repository factory for database operations
+        workspace_root: Root directory of the MoSeq2 workspace
+        session_index_csv: Path to session_index_filtered.csv
+        check_paths_exist: If True, create QC events for missing file paths
+
+    Returns:
+        ImportStats with counts of imported entities
+    """
+    stats = ImportStats()
+
+    # Read CSV
+    df = pd.read_csv(session_index_csv)
+    stats.rows_total = len(df)
+
+    workspace_root = Path(workspace_root).resolve()
+
+    for _, row in df.iterrows():
+        # Extract subject information
+        subject_id = str(row.get("subject_id", "")).strip()
+        if not subject_id:
+            continue  # Skip rows without subject_id
+
+        # Parse subject fields
+        sex = _parse_sex(row.get("sex"))
+        genotype = str(row.get("genotype", "")).strip() or None
+        birthdate = _parse_date(row.get("birthdate"))
+
+        # Create/upsert subject
+        subject = Subject(
+            id=subject_id,
+            colony_id=None,  # No colony association from CSV
+            sex=sex,
+            designation=SubjectDesignation.EXPERIMENTAL,
+            birth_date=birthdate,
+            individual_genotype=genotype,
+            individual_treatment=str(row.get("treatment", "")).strip() or None,
+        )
+        repos.subjects.save(subject)
+        stats.subjects_upserted += 1
+
+        # Extract experiment information
+        session_id = str(row.get("session_id", "")).strip()
+        if not session_id:
+            session_id = f"{subject_id}_{row.get('recording_date', 'unknown')}"
+
+        task = str(row.get("task", "")).strip() or "unknown"
+        recording_date = _parse_date(row.get("recording_date"))
+        if not recording_date:
+            recording_date = datetime.now()  # Fallback
+
+        # Create/upsert experiment
+        experiment = Experiment(
+            id=session_id,
+            subject_id=subject_id,
+            experiment_type=task,
+            date_recorded=recording_date,
+            processing_stage=ProcessingStage.RECORDED,  # Assume recorded since we have data
+        )
+        repos.experiments.save(experiment)
+        stats.experiments_upserted += 1
+
+        # Handle video path
+        video_path = _as_path(row.get("video_path"))
+        if video_path:
+            video_path = _resolve_path(video_path, workspace_root)
+            # Save video (path-only, no hash)
+            repos.videos.save(VideoFile(path=video_path, hash=None))
+            stats.videos_upserted += 1
+            # Link video to experiment
+            repos.experiments.add_video_to_experiment_by_path(experiment.id, video_path)
+
+            # Store as external artifact
+            repos.external_artifacts.add(
+                kind="video_path",
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path=str(video_path),
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+            # Check if video exists
+            if check_paths_exist and not video_path.exists():
+                repos.qc_events.add(
+                    scope="artifact",
+                    code="MISSING_PATH",
+                    subject_id=subject_id,
+                    experiment_id=experiment.id,
+                    details={"kind": "video_path", "path": str(video_path)},
+                )
+                stats.qc_events_added += 1
+
+        # Artifact columns to index directly
+        artifact_cols = [
+            "dlc_csv_path",
+            "moseq2_results_h5_path",
+            "moseq2_results_yaml_path",
+            "moseq2_metadata_path",
+            "moseq2_identifier_path",
+            "syllable_stats_path",
+            "syllable_h5_path",
+            "kpms_syllable_stats_path",
+        ]
+
+        for col in artifact_cols:
+            p = _as_path(row.get(col))
+            if not p:
+                continue
+
+            p = _resolve_path(p, workspace_root)
+
+            # Store as external artifact
+            repos.external_artifacts.add(
+                kind=col,
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path=str(p),
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+            # Check if path exists
+            if check_paths_exist and not p.exists():
+                repos.qc_events.add(
+                    scope="artifact",
+                    code="MISSING_PATH",
+                    subject_id=subject_id,
+                    experiment_id=experiment.id,
+                    details={"kind": col, "path": str(p)},
+                )
+                stats.qc_events_added += 1
+
+        # Store scalar identifiers as meta on an artifact record
+        identifiers: Dict[str, Any] = {}
+        for k in (
+            "syllable_uuid",
+            "kpms_recording_id",
+            "moseq2_session_name",
+            "arena_bucket",
+            "moseq2_source_filename",
+        ):
+            v = str(row.get(k, "")).strip()
+            if v:
+                identifiers[k] = v
+
+        if identifiers:
+            repos.external_artifacts.add(
+                kind="identifiers",
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path="",  # No file path for identifiers
+                payload_json=json.dumps(identifiers),  # Store as JSON string
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+    return stats

--- a/src/mus1/core/importers/rotarod.py
+++ b/src/mus1/core/importers/rotarod.py
@@ -1,0 +1,269 @@
+"""Importer for rotarod assay CSV data."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from ..metadata import AssaySession, AssayMeasurement, Subject, Sex, SubjectDesignation
+from ..repository import RepositoryFactory
+
+
+@dataclass(frozen=True)
+class RotarodImportStats:
+    """Statistics from rotarod import."""
+    rows_total: int
+    assay_sessions_created: int
+    assay_measurements_created: int
+    subjects_created: int
+    subjects_skipped: int
+    errors: int
+
+
+def _parse_date(value: str) -> Optional[datetime]:
+    """Parse date string to datetime."""
+    if not value or not value.strip():
+        return None
+    try:
+        # Try YYYY-MM-DD format
+        return datetime.strptime(value.strip(), "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _normalize_tag_number(tag: str) -> str:
+    """Normalize tag number (remove leading zeros)."""
+    try:
+        return str(int(tag.strip()))
+    except (ValueError, AttributeError):
+        return str(tag).strip()
+
+
+def _ensure_subject_exists(
+    repos: RepositoryFactory,
+    tag_number: str,
+    sex: Optional[str] = None,
+    genotype: Optional[str] = None,
+) -> Tuple[Optional[Subject], bool]:
+    """
+    Ensure subject exists, creating if necessary.
+    
+    Returns:
+        Tuple of (subject, was_created) where was_created is True if subject was just created
+    """
+    tag_normalized = _normalize_tag_number(tag_number)
+    
+    # Try to find existing subject
+    subject = repos.subjects.find_by_id(tag_normalized)
+    if subject:
+        return subject, False
+    
+    # Create new subject if not found
+    # Map sex string to enum
+    sex_enum = Sex.UNKNOWN
+    if sex:
+        sex_upper = sex.strip().upper()
+        if sex_upper == "M":
+            sex_enum = Sex.MALE
+        elif sex_upper == "F":
+            sex_enum = Sex.FEMALE
+    
+    subject = Subject(
+        id=tag_normalized,
+        colony_id=None,
+        sex=sex_enum,
+        designation=SubjectDesignation.EXPERIMENTAL,
+        individual_genotype=genotype.strip() if genotype else None,
+    )
+    
+    try:
+        created_subject = repos.subjects.save(subject)
+        return created_subject, True
+    except Exception:
+        # Subject creation failed (e.g., constraint violation)
+        return None, False
+
+
+def import_rotarod_csv(
+    repos: RepositoryFactory,
+    csv_path: Path,
+    assay_type: str = "rotarod",
+) -> RotarodImportStats:
+    """
+    Import rotarod assay data from CSV.
+    
+    Creates assay_sessions per (tag_number, session_id) and assay_measurements
+    for each row with metrics like time_sec, speed_rpm, attempt.
+    
+    Args:
+        repos: Repository factory for database operations
+        csv_path: Path to rotarod CSV file
+        assay_type: Type identifier for assay sessions (default: "rotarod")
+    
+    Returns:
+        Import statistics
+    """
+    rows_total = 0
+    assay_sessions_created = 0
+    assay_measurements_created = 0
+    subjects_created = 0
+    subjects_skipped = 0
+    errors = 0
+    
+    # Track created sessions by (tag_number, session_id) to avoid duplicates
+    session_cache: Dict[Tuple[str, str], int] = {}
+    
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+    
+    with open(csv_path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        
+        for row in reader:
+            rows_total += 1
+            
+            try:
+                tag_number = row.get("tag_number", "").strip()
+                session_id = row.get("session_id", "").strip()
+                
+                if not tag_number or not session_id:
+                    errors += 1
+                    continue
+                
+                # Ensure subject exists
+                sex = row.get("sex_final", "").strip()
+                genotype = row.get("genotype_final", "").strip()
+                subject, was_created = _ensure_subject_exists(repos, tag_number, sex, genotype)
+                
+                if not subject:
+                    subjects_skipped += 1
+                    errors += 1
+                    continue
+                
+                if was_created:
+                    subjects_created += 1
+                
+                # Check if we already created this session
+                # Use normalized tag_number for consistency
+                tag_normalized = _normalize_tag_number(tag_number)
+                session_key = (tag_normalized, session_id)
+                assay_session_id = session_cache.get(session_key)
+                
+                if assay_session_id is None:
+                    # Create new assay session
+                    test_date_str = row.get("test_date", "").strip()
+                    occurred_at = _parse_date(test_date_str)
+                    
+                    # Collect metadata for session
+                    session_meta: Dict[str, Any] = {
+                        "source_file": row.get("source_file", "").strip(),
+                        "session_index": row.get("session_index", "").strip(),
+                        "genotype_final": genotype,
+                        "sex_final": sex,
+                        "birthdate_final": row.get("birthdate_final", "").strip(),
+                        "treatment_roster": row.get("treatment_roster", "").strip(),
+                        "age_days": row.get("age_days", "").strip(),
+                    }
+                    
+                    assay_session = AssaySession(
+                        assay_type=assay_type,
+                        subject_id=subject.id,
+                        occurred_at=occurred_at,
+                        experiment_id=None,  # No experiment linkage for rotarod
+                        source_path=csv_path,
+                        meta=session_meta,
+                    )
+                    
+                    assay_session_id = repos.assay_sessions.create(assay_session)
+                    session_cache[session_key] = assay_session_id
+                    assay_sessions_created += 1
+                
+                # Create measurements for this row
+                # Measurement 1: time_sec
+                time_sec_str = row.get("time_sec", "").strip()
+                if time_sec_str:
+                    try:
+                        time_value = float(time_sec_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="time_sec",
+                            value=time_value,
+                            units="seconds",
+                            qc_flags=qc_flags,
+                            details={
+                                "attempt": row.get("attempt", "").strip(),
+                                "speed_rpm": row.get("speed_rpm", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid time_sec
+                
+                # Measurement 2: speed_rpm
+                speed_rpm_str = row.get("speed_rpm", "").strip()
+                if speed_rpm_str:
+                    try:
+                        speed_value = float(speed_rpm_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="speed_rpm",
+                            value=speed_value,
+                            units="rpm",
+                            qc_flags=qc_flags,
+                            details={
+                                "attempt": row.get("attempt", "").strip(),
+                                "time_sec": row.get("time_sec", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid speed_rpm
+                
+                # Measurement 3: attempt (as a metric)
+                attempt_str = row.get("attempt", "").strip()
+                if attempt_str:
+                    try:
+                        attempt_value = float(attempt_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="attempt",
+                            value=attempt_value,
+                            units=None,
+                            qc_flags=qc_flags,
+                            details={
+                                "time_sec": row.get("time_sec", "").strip(),
+                                "speed_rpm": row.get("speed_rpm", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid attempt
+                
+            except Exception as e:
+                errors += 1
+                # Continue processing other rows
+                continue
+    
+    return RotarodImportStats(
+        rows_total=rows_total,
+        assay_sessions_created=assay_sessions_created,
+        assay_measurements_created=assay_measurements_created,
+        subjects_created=subjects_created,
+        subjects_skipped=subjects_skipped,
+        errors=errors,
+    )

--- a/src/mus1/core/metadata.py
+++ b/src/mus1/core/metadata.py
@@ -196,10 +196,34 @@ class Experiment:
 class VideoFile:
     """Core video file entity."""
     path: Path
-    hash: str
+    hash: Optional[str] = None
     recorded_time: Optional[datetime] = None
     size_bytes: int = 0
     last_modified: float = 0.0
+    date_added: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class AssaySession:
+    """A non-video assay session (e.g. rotarod) linked to a subject (and optionally an experiment)."""
+    assay_type: str
+    subject_id: str
+    occurred_at: Optional[datetime] = None
+    experiment_id: Optional[str] = None
+    source_path: Optional[Path] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+    date_added: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class AssayMeasurement:
+    """A single measurement within an assay session."""
+    assay_session_id: int
+    metric: str
+    value: Optional[float] = None
+    units: Optional[str] = None
+    qc_flags: List[str] = field(default_factory=list)
+    details: Dict[str, Any] = field(default_factory=dict)
     date_added: datetime = field(default_factory=datetime.now)
 
 @dataclass

--- a/src/mus1/core/project_manager_clean.py
+++ b/src/mus1/core/project_manager_clean.py
@@ -251,11 +251,12 @@ class ProjectManagerClean:
 
     def add_video(self, video: VideoFile) -> VideoFile:
         """Add a video file to the project."""
-        # Check for duplicates
-        existing = self.repos.videos.find_by_hash(video.hash)
-        if existing:
-            logger.warning(f"Video with hash {video.hash} already exists: {existing.path}")
-            return existing
+        # Check for duplicates (only when a hash is available)
+        if video.hash:
+            existing = self.repos.videos.find_by_hash(video.hash)
+            if existing:
+                logger.warning(f"Video with hash {video.hash} already exists: {existing.path}")
+                return existing
 
         logger.info(f"Adding video {video.path} to project {self.config.name}")
         saved_video = self.repos.videos.save(video)

--- a/src/mus1/core/repository.py
+++ b/src/mus1/core/repository.py
@@ -14,6 +14,7 @@ from .schema import (
     Database, SubjectModel, ExperimentModel, VideoModel,
     WorkerModel, ScanTargetModel, ProjectModel, ColonyModel,
     AssaySessionModel, AssayMeasurementModel,
+    ExternalArtifactModel, QCEventModel,
     TrackedObjectModel, BodyPartModel, TreatmentModel, GenotypeModel,
     subject_to_model, model_to_subject,
     experiment_to_model, model_to_experiment,
@@ -455,6 +456,72 @@ class AssayMeasurementRepository(BaseRepository):
             session.commit()
             return int(row.id)
 
+
+class ExternalArtifactRepository(BaseRepository):
+    """Repository for artifact pointers (path-first)."""
+
+    def add(
+        self,
+        *,
+        kind: str,
+        path: str,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+        content_sha256: Optional[str] = None,
+        payload_json: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Add an external artifact and return its integer ID."""
+        from datetime import datetime
+        from .schema import ExternalArtifactModel
+        with self._get_session() as session:
+            row = ExternalArtifactModel(
+                kind=kind,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                path=path,
+                content_sha256=content_sha256,
+                payload_json=payload_json,
+                meta_json=json.dumps(meta or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
+
+class QCEventRepository(BaseRepository):
+    """Repository for non-fatal QC events."""
+
+    def add(
+        self,
+        *,
+        scope: str,
+        code: str,
+        details: Optional[Dict[str, Any]] = None,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+    ) -> int:
+        """Add a QC event and return its integer ID."""
+        from datetime import datetime
+        from .schema import QCEventModel
+        with self._get_session() as session:
+            row = QCEventModel(
+                scope=scope,
+                code=code,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                details_json=json.dumps(details or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
 class WorkerRepository(BaseRepository):
     """Repository for worker operations."""
 
@@ -875,6 +942,8 @@ class RepositoryFactory:
         # Dataset-first extensions
         self._assay_sessions: Optional[AssaySessionRepository] = None
         self._assay_measurements: Optional[AssayMeasurementRepository] = None
+        self._external_artifacts: Optional[ExternalArtifactRepository] = None
+        self._qc_events: Optional[QCEventRepository] = None
         # Metadata repositories
         self._tracked_objects: Optional[TrackedObjectRepository] = None
         self._body_parts: Optional[BodyPartRepository] = None
@@ -934,6 +1003,18 @@ class RepositoryFactory:
         if self._assay_measurements is None:
             self._assay_measurements = AssayMeasurementRepository(self.db)
         return self._assay_measurements
+
+    @property
+    def external_artifacts(self) -> ExternalArtifactRepository:
+        if self._external_artifacts is None:
+            self._external_artifacts = ExternalArtifactRepository(self.db)
+        return self._external_artifacts
+
+    @property
+    def qc_events(self) -> QCEventRepository:
+        if self._qc_events is None:
+            self._qc_events = QCEventRepository(self.db)
+        return self._qc_events
 
     @property
 # Removed: scan_targets() method (part of scan target functionality)

--- a/src/mus1/core/repository.py
+++ b/src/mus1/core/repository.py
@@ -4,14 +4,16 @@ Repository layer for clean data access patterns.
 This provides a clean abstraction over the SQLite database for domain operations.
 """
 
+import json
 from typing import List, Optional, Dict, Any
 from pathlib import Path
 from sqlalchemy.orm import Session
 from sqlalchemy import text
-from .metadata import Subject, Experiment, VideoFile, Worker, ScanTarget
+from .metadata import Subject, Experiment, VideoFile, Worker, ScanTarget, AssaySession, AssayMeasurement
 from .schema import (
     Database, SubjectModel, ExperimentModel, VideoModel,
     WorkerModel, ScanTargetModel, ProjectModel, ColonyModel,
+    AssaySessionModel, AssayMeasurementModel,
     TrackedObjectModel, BodyPartModel, TreatmentModel, GenotypeModel,
     subject_to_model, model_to_subject,
     experiment_to_model, model_to_experiment,
@@ -351,8 +353,10 @@ class VideoRepository(BaseRepository):
                     date_added=db_video.date_added
                 )
 
-    def find_by_hash(self, hash_value: str) -> Optional[VideoFile]:
+    def find_by_hash(self, hash_value: Optional[str]) -> Optional[VideoFile]:
         """Find video by hash."""
+        if not hash_value:
+            return None
         with self._get_session() as session:
             db_video = session.query(VideoModel).filter(
                 VideoModel.hash == hash_value
@@ -393,7 +397,7 @@ class VideoRepository(BaseRepository):
             duplicates = session.query(
                 VideoModel.hash,
                 func.count(VideoModel.id).label('count')
-            ).group_by(VideoModel.hash).having(func.count(VideoModel.id) > 1).all()
+            ).filter(VideoModel.hash.isnot(None)).group_by(VideoModel.hash).having(func.count(VideoModel.id) > 1).all()
 
             result = []
             for hash_val, count in duplicates:
@@ -410,6 +414,46 @@ class VideoRepository(BaseRepository):
                     } for v in videos]
                 })
             return result
+
+
+class AssaySessionRepository(BaseRepository):
+    """Repository for assay session operations."""
+
+    def create(self, assay: AssaySession) -> int:
+        """Insert an assay session and return its integer ID."""
+        with self._get_session() as session:
+            row = AssaySessionModel(
+                assay_type=assay.assay_type,
+                subject_id=assay.subject_id,
+                occurred_at=assay.occurred_at,
+                experiment_id=assay.experiment_id,
+                source_path=str(assay.source_path) if assay.source_path else None,
+                meta_json=json.dumps(assay.meta or {}),
+                created_at=assay.date_added,
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
+
+class AssayMeasurementRepository(BaseRepository):
+    """Repository for assay measurement operations."""
+
+    def add(self, m: AssayMeasurement) -> int:
+        """Insert a measurement and return its integer ID."""
+        with self._get_session() as session:
+            row = AssayMeasurementModel(
+                assay_session_id=m.assay_session_id,
+                metric=m.metric,
+                value=m.value,
+                units=m.units,
+                qc_flags_json=json.dumps(m.qc_flags or []),
+                details_json=json.dumps(m.details or {}),
+                created_at=m.date_added,
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
 
 class WorkerRepository(BaseRepository):
     """Repository for worker operations."""
@@ -828,6 +872,9 @@ class RepositoryFactory:
         self._videos: Optional[VideoRepository] = None
         self._workers: Optional[WorkerRepository] = None
 # Removed: _scan_targets (part of scan target functionality)
+        # Dataset-first extensions
+        self._assay_sessions: Optional[AssaySessionRepository] = None
+        self._assay_measurements: Optional[AssayMeasurementRepository] = None
         # Metadata repositories
         self._tracked_objects: Optional[TrackedObjectRepository] = None
         self._body_parts: Optional[BodyPartRepository] = None
@@ -875,6 +922,18 @@ class RepositoryFactory:
         if self._workers is None:
             self._workers = WorkerRepository(self.db)
         return self._workers
+
+    @property
+    def assay_sessions(self) -> AssaySessionRepository:
+        if self._assay_sessions is None:
+            self._assay_sessions = AssaySessionRepository(self.db)
+        return self._assay_sessions
+
+    @property
+    def assay_measurements(self) -> AssayMeasurementRepository:
+        if self._assay_measurements is None:
+            self._assay_measurements = AssayMeasurementRepository(self.db)
+        return self._assay_measurements
 
     @property
 # Removed: scan_targets() method (part of scan target functionality)

--- a/src/mus1/core/repository.py
+++ b/src/mus1/core/repository.py
@@ -7,6 +7,7 @@ This provides a clean abstraction over the SQLite database for domain operations
 import json
 from typing import List, Optional, Dict, Any
 from pathlib import Path
+from datetime import datetime
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 from .metadata import Subject, Experiment, VideoFile, Worker, ScanTarget, AssaySession, AssayMeasurement
@@ -14,6 +15,7 @@ from .schema import (
     Database, SubjectModel, ExperimentModel, VideoModel,
     WorkerModel, ScanTargetModel, ProjectModel, ColonyModel,
     AssaySessionModel, AssayMeasurementModel,
+    ExternalArtifactModel, QCEventModel,
     TrackedObjectModel, BodyPartModel, TreatmentModel, GenotypeModel,
     subject_to_model, model_to_subject,
     experiment_to_model, model_to_experiment,
@@ -455,6 +457,104 @@ class AssayMeasurementRepository(BaseRepository):
             session.commit()
             return int(row.id)
 
+
+class ExternalArtifactRepository(BaseRepository):
+    """Repository for external artifact operations."""
+
+    def add(
+        self,
+        *,
+        kind: str,
+        path: str,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+        content_sha256: Optional[str] = None,
+        payload_json: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Add an external artifact. Returns the artifact ID."""
+        with self._get_session() as session:
+            row = ExternalArtifactModel(
+                kind=kind,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                path=path,
+                content_sha256=content_sha256,
+                payload_json=payload_json,
+                meta_json=json.dumps(meta or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
+    def find_by_experiment(self, experiment_id: str) -> List[Dict[str, Any]]:
+        """Find all artifacts for an experiment."""
+        with self._get_session() as session:
+            artifacts = session.query(ExternalArtifactModel).filter(
+                ExternalArtifactModel.experiment_id == experiment_id
+            ).all()
+            return [
+                {
+                    "id": a.id,
+                    "kind": a.kind,
+                    "path": a.path,
+                    "subject_id": a.subject_id,
+                    "experiment_id": a.experiment_id,
+                    "meta": json.loads(a.meta_json) if a.meta_json else {},
+                }
+                for a in artifacts
+            ]
+
+    def find_by_subject(self, subject_id: str) -> List[Dict[str, Any]]:
+        """Find all artifacts for a subject."""
+        with self._get_session() as session:
+            artifacts = session.query(ExternalArtifactModel).filter(
+                ExternalArtifactModel.subject_id == subject_id
+            ).all()
+            return [
+                {
+                    "id": a.id,
+                    "kind": a.kind,
+                    "path": a.path,
+                    "subject_id": a.subject_id,
+                    "experiment_id": a.experiment_id,
+                    "meta": json.loads(a.meta_json) if a.meta_json else {},
+                }
+                for a in artifacts
+            ]
+
+
+class QCEventRepository(BaseRepository):
+    """Repository for QC event operations."""
+
+    def add(
+        self,
+        *,
+        scope: str,
+        code: str,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Add a QC event. Returns the event ID."""
+        with self._get_session() as session:
+            row = QCEventModel(
+                scope=scope,
+                code=code,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                details_json=json.dumps(details or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
 class WorkerRepository(BaseRepository):
     """Repository for worker operations."""
 
@@ -875,6 +975,8 @@ class RepositoryFactory:
         # Dataset-first extensions
         self._assay_sessions: Optional[AssaySessionRepository] = None
         self._assay_measurements: Optional[AssayMeasurementRepository] = None
+        self._external_artifacts: Optional[ExternalArtifactRepository] = None
+        self._qc_events: Optional[QCEventRepository] = None
         # Metadata repositories
         self._tracked_objects: Optional[TrackedObjectRepository] = None
         self._body_parts: Optional[BodyPartRepository] = None
@@ -934,6 +1036,18 @@ class RepositoryFactory:
         if self._assay_measurements is None:
             self._assay_measurements = AssayMeasurementRepository(self.db)
         return self._assay_measurements
+
+    @property
+    def external_artifacts(self) -> ExternalArtifactRepository:
+        if self._external_artifacts is None:
+            self._external_artifacts = ExternalArtifactRepository(self.db)
+        return self._external_artifacts
+
+    @property
+    def qc_events(self) -> QCEventRepository:
+        if self._qc_events is None:
+            self._qc_events = QCEventRepository(self.db)
+        return self._qc_events
 
     @property
 # Removed: scan_targets() method (part of scan target functionality)

--- a/src/mus1/core/schema.py
+++ b/src/mus1/core/schema.py
@@ -77,7 +77,9 @@ class VideoModel(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     path = Column(String, nullable=False, unique=True)
-    hash = Column(String, nullable=False, index=True)
+    # NOTE: Hash is optional to support "path-only" datasets on Chinook.
+    # When present, it can be used for dedupe/verification.
+    hash = Column(String, nullable=True, index=True)
     recorded_time = Column(DateTime, nullable=True)
     size_bytes = Column(Integer, default=0)
     last_modified = Column(Float, default=0.0)
@@ -176,6 +178,69 @@ class PluginResultModel(Base):
     output_files = Column(Text, default="{}")  # JSON-encoded list of output file paths
     created_at = Column(DateTime, nullable=False)
     completed_at = Column(DateTime, nullable=True)
+
+
+# ===========================================
+# DATASET-FIRST EXTENSIONS (assays, artifacts, QC)
+# ===========================================
+
+class AssaySessionModel(Base):
+    """Database model for non-video assay sessions (e.g. rotarod)."""
+    __tablename__ = 'assay_sessions'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    assay_type = Column(String, nullable=False, index=True)
+    subject_id = Column(String, ForeignKey('subjects.id'), nullable=False, index=True)
+    occurred_at = Column(DateTime, nullable=True, index=True)
+    experiment_id = Column(String, ForeignKey('experiments.id'), nullable=True, index=True)
+    source_path = Column(Text, nullable=True)
+    meta_json = Column(Text, default="{}")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class AssayMeasurementModel(Base):
+    """Database model for measurements taken within an assay session."""
+    __tablename__ = 'assay_measurements'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    assay_session_id = Column(Integer, ForeignKey('assay_sessions.id'), nullable=False, index=True)
+    metric = Column(String, nullable=False, index=True)
+    value = Column(Float, nullable=True)
+    units = Column(String, nullable=True)
+    qc_flags_json = Column(Text, default="[]")
+    details_json = Column(Text, default="{}")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class ExternalArtifactModel(Base):
+    """Pointer to an external artifact file (path-first; optional payload for small JSON)."""
+    __tablename__ = 'external_artifacts'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    kind = Column(String, nullable=False, index=True)
+    # Linkage (nullable to allow incomplete data during import/QC)
+    subject_id = Column(String, ForeignKey('subjects.id'), nullable=True, index=True)
+    experiment_id = Column(String, ForeignKey('experiments.id'), nullable=True, index=True)
+    assay_session_id = Column(Integer, ForeignKey('assay_sessions.id'), nullable=True, index=True)
+    path = Column(Text, nullable=False)
+    content_sha256 = Column(String, nullable=True, index=True)
+    payload_json = Column(Text, nullable=True)
+    meta_json = Column(Text, default="{}")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class QCEventModel(Base):
+    """Non-fatal integrity / QC event recorded during import and processing."""
+    __tablename__ = 'qc_events'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    scope = Column(String, nullable=False, index=True)  # e.g. subject|experiment|video|artifact|assay
+    code = Column(String, nullable=False, index=True)   # e.g. MISSING_DLC_CSV, CORRUPT_MP4
+    subject_id = Column(String, ForeignKey('subjects.id'), nullable=True, index=True)
+    experiment_id = Column(String, ForeignKey('experiments.id'), nullable=True, index=True)
+    assay_session_id = Column(Integer, ForeignKey('assay_sessions.id'), nullable=True, index=True)
+    details_json = Column(Text, default="{}")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
 
 class UserModel(Base):
     """Database model for users."""

--- a/src/mus1/core/simple_cli.py
+++ b/src/mus1/core/simple_cli.py
@@ -285,6 +285,66 @@ def project_status(
     rich_print(f"[bold]Experiments:[/bold] {stats['experiments']}")
     rich_print(f"[bold]Videos:[/bold] {stats['videos']}")
 
+@project_app.command("import-kpms-recordings")
+def import_kpms_recordings_cmd(
+    csv_paths: str = typer.Argument(..., help="Comma-separated paths to recordings CSV files"),
+    workspace_root: Path = typer.Option(..., "--workspace-root", help="Workspace root directory"),
+    project_path: Path = typer.Option(Path.cwd(), help="Project directory"),
+):
+    """Import KPMS recordings metadata from CSV files."""
+    from .importers.kpms_recordings import import_kpms_recordings
+    
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No database found at {db_path}")
+        rich_print("[blue]ℹ[/blue] Run 'mus1 project init' first")
+        raise typer.Exit(1)
+    
+    # Parse CSV paths
+    csv_file_paths = [Path(p.strip()) for p in csv_paths.split(',')]
+    
+    # Validate paths
+    for csv_path in csv_file_paths:
+        if not csv_path.exists():
+            rich_print(f"[red]✗[/red] CSV file not found: {csv_path}")
+            raise typer.Exit(1)
+    
+    if not workspace_root.exists():
+        rich_print(f"[red]✗[/red] Workspace root not found: {workspace_root}")
+        raise typer.Exit(1)
+    
+    rich_print(f"[blue]ℹ[/blue] Importing {len(csv_file_paths)} CSV file(s)...")
+    rich_print(f"[blue]ℹ[/blue] Workspace root: {workspace_root}")
+    rich_print(f"[blue]ℹ[/blue] Database: {db_path}")
+    
+    try:
+        stats = import_kpms_recordings(db_path, csv_file_paths, workspace_root)
+        
+        rich_print("\n[bold green]✓ Import completed![/bold green]")
+        rich_print(f"\n[bold]Summary:[/bold]")
+        rich_print(f"  Total artifacts added: {stats['total_artifacts']}")
+        rich_print(f"  Linked to experiments: {stats['total_linked_to_experiment']}")
+        rich_print(f"  Linked to subjects: {stats['total_linked_to_subject']}")
+        rich_print(f"  Unlinked: {stats['total_unlinked']}")
+        
+        if stats['sources']:
+            rich_print(f"\n[bold]By source:[/bold]")
+            for source_name, source_stats in stats['sources'].items():
+                if 'error' in source_stats:
+                    rich_print(f"  [red]✗[/red] {source_name}: {source_stats['error']}")
+                else:
+                    rich_print(f"  [green]✓[/green] {source_name}:")
+                    rich_print(f"    Artifacts: {source_stats['artifacts_added']}")
+                    rich_print(f"    Linked to exp: {source_stats['linked_to_experiment']}")
+                    rich_print(f"    Linked to subject: {source_stats['linked_to_subject']}")
+                    rich_print(f"    Unlinked: {source_stats['unlinked']}")
+    
+    except Exception as e:
+        rich_print(f"[red]✗[/red] Import failed: {e}")
+        import traceback
+        rich_print(traceback.format_exc())
+        raise typer.Exit(1)
+
 # ===========================================
 # DATA MANAGEMENT
 # ===========================================
@@ -490,6 +550,69 @@ def scan_videos(
             rich_print(f"  {video['path']}")
         if len(videos) > 5:
             rich_print(f"  ... and {len(videos) - 5} more")
+
+@app.command("test-kpms-import")
+def test_kpms_import(
+    csv_path: Path = typer.Argument(..., help="Path to a recordings CSV file"),
+    workspace_root: Path = typer.Option(..., "--workspace-root", help="Workspace root directory"),
+    project_path: Path = typer.Option(Path.cwd(), help="Project directory"),
+):
+    """Smoke test for KPMS recordings import (dry-run, shows what would be imported)."""
+    from .importers.kpms_recordings import import_kpms_recordings_csv
+    from .repository import get_repository_factory
+    
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No database found at {db_path}")
+        rich_print("[blue]ℹ[/blue] Run 'mus1 project init' first")
+        raise typer.Exit(1)
+    
+    if not csv_path.exists():
+        rich_print(f"[red]✗[/red] CSV file not found: {csv_path}")
+        raise typer.Exit(1)
+    
+    if not workspace_root.exists():
+        rich_print(f"[red]✗[/red] Workspace root not found: {workspace_root}")
+        raise typer.Exit(1)
+    
+    rich_print("[blue]ℹ[/blue] Running smoke test (dry-run)...")
+    rich_print(f"[blue]ℹ[/blue] CSV: {csv_path}")
+    rich_print(f"[blue]ℹ[/blue] Workspace root: {workspace_root}")
+    
+    # Extract source name
+    source_name = csv_path.parent.parent.name if csv_path.name == "recordings.csv" else csv_path.stem
+    
+    try:
+        from .schema import Database
+        db = Database(str(db_path))
+        db.create_tables()
+        repos = get_repository_factory(db)
+        
+        # Count before
+        from .schema import ExternalArtifactModel
+        with db.get_session() as session:
+            before_count = session.query(ExternalArtifactModel).count()
+        
+        # Run import
+        stats = import_kpms_recordings_csv(repos, csv_path, workspace_root, source_name)
+        
+        # Count after
+        with db.get_session() as session:
+            after_count = session.query(ExternalArtifactModel).count()
+        
+        rich_print("\n[bold green]✓ Smoke test passed![/bold green]")
+        rich_print(f"\n[bold]Results:[/bold]")
+        rich_print(f"  Artifacts added: {stats['artifacts_added']}")
+        rich_print(f"  Linked to experiments: {stats['linked_to_experiment']}")
+        rich_print(f"  Linked to subjects: {stats['linked_to_subject']}")
+        rich_print(f"  Unlinked: {stats['unlinked']}")
+        rich_print(f"  Total artifacts in DB: {before_count} -> {after_count}")
+        
+    except Exception as e:
+        rich_print(f"[red]✗[/red] Smoke test failed: {e}")
+        import traceback
+        rich_print(traceback.format_exc())
+        raise typer.Exit(1)
 
 # ===========================================
 # SETUP COMMANDS

--- a/src/mus1/core/simple_cli.py
+++ b/src/mus1/core/simple_cli.py
@@ -42,6 +42,10 @@ app.add_typer(lab_app, name="lab")
 project_app = typer.Typer(help="Project management commands")
 app.add_typer(project_app, name="project")
 
+# Import subcommand group
+import_app = typer.Typer(help="Dataset import commands")
+app.add_typer(import_app, name="import")
+
 # ===========================================
 # CORE COMMANDS
 # ===========================================
@@ -284,6 +288,61 @@ def project_status(
     rich_print(f"[bold]Subjects:[/bold] {stats['subjects']}")
     rich_print(f"[bold]Experiments:[/bold] {stats['experiments']}")
     rich_print(f"[bold]Videos:[/bold] {stats['videos']}")
+
+# ===========================================
+# IMPORT COMMANDS
+# ===========================================
+
+@import_app.command("moseq2-workspace")
+def import_moseq2_workspace(
+    project_path: Path = typer.Option(..., help="Target MUS1 project directory (contains mus1.db)"),
+    workspace_root: Path = typer.Option(..., help="MoSeq2 workspace root"),
+    index_csv: Path = typer.Option(
+        None,
+        help="Compiled session index CSV (defaults to ml_tracking_metadata_model/index/session_index_filtered.csv under workspace_root)",
+    ),
+    check_paths_exist: bool = typer.Option(True, help="Record QC events for missing paths"),
+):
+    """Import MoSeq2 workspace session index into a MUS1 project DB (path-only; non-fatal QC)."""
+    from .schema import Database
+    from .repository import get_repository_factory
+    from .importers.moseq2_workspace import import_session_index
+
+    if not project_path.exists():
+        rich_print(f"[red]✗[/red] Project path does not exist: {project_path}")
+        raise typer.Exit(1)
+
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No mus1.db found at: {db_path}")
+        rich_print("[blue]ℹ[/blue] Create one with: mus1 project init \"<name>\" --path <project_path>")
+        raise typer.Exit(1)
+
+    if index_csv is None:
+        index_csv = workspace_root / "ml_tracking_metadata_model" / "index" / "session_index_filtered.csv"
+
+    if not index_csv.exists():
+        rich_print(f"[red]✗[/red] Index CSV not found: {index_csv}")
+        raise typer.Exit(1)
+
+    db = Database(str(db_path))
+    db.create_tables()
+    repos = get_repository_factory(db)
+
+    stats = import_session_index(
+        repos,
+        workspace_root=workspace_root,
+        session_index_csv=index_csv,
+        check_paths_exist=check_paths_exist,
+    )
+
+    rich_print("[green]✓[/green] Import complete")
+    rich_print(f"[blue]ℹ[/blue] Rows: {stats.rows_total}")
+    rich_print(f"[blue]ℹ[/blue] Subjects upserted: {stats.subjects_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Experiments upserted: {stats.experiments_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Videos upserted: {stats.videos_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Artifacts added: {stats.artifacts_added}")
+    rich_print(f"[blue]ℹ[/blue] QC events added: {stats.qc_events_added}")
 
 # ===========================================
 # DATA MANAGEMENT

--- a/src/mus1/core/simple_cli.py
+++ b/src/mus1/core/simple_cli.py
@@ -349,6 +349,51 @@ def add_subject(
     if subject.genotype:
         rich_print(f"[blue]ℹ[/blue] Genotype: {subject.genotype}")
 
+@app.command("import-rotarod")
+def import_rotarod(
+    project_path: Path = typer.Option(..., help="Target MUS1 project directory (contains mus1.db)"),
+    csv_path: Path = typer.Option(..., help="Path to rotarod CSV file"),
+    assay_type: str = typer.Option("rotarod", help="Assay type identifier"),
+):
+    """Import rotarod assay data from CSV into a MUS1 project DB."""
+    from .schema import Database
+    from .repository import get_repository_factory
+    from .importers.rotarod import import_rotarod_csv
+
+    if not project_path.exists():
+        rich_print(f"[red]✗[/red] Project path does not exist: {project_path}")
+        raise typer.Exit(1)
+
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No mus1.db found at: {db_path}")
+        rich_print("[blue]ℹ[/blue] Create one with: mus1 project init \"<name>\" --path <project_path>")
+        raise typer.Exit(1)
+
+    if not csv_path.exists():
+        rich_print(f"[red]✗[/red] CSV file not found: {csv_path}")
+        raise typer.Exit(1)
+
+    db = Database(str(db_path))
+    db.create_tables()
+    repos = get_repository_factory(db)
+
+    stats = import_rotarod_csv(
+        repos,
+        csv_path=csv_path,
+        assay_type=assay_type,
+    )
+
+    rich_print("[green]✓[/green] Import complete")
+    rich_print(f"[blue]ℹ[/blue] Rows processed: {stats.rows_total}")
+    rich_print(f"[blue]ℹ[/blue] Assay sessions created: {stats.assay_sessions_created}")
+    rich_print(f"[blue]ℹ[/blue] Assay measurements created: {stats.assay_measurements_created}")
+    rich_print(f"[blue]ℹ[/blue] Subjects created: {stats.subjects_created}")
+    if stats.subjects_skipped > 0:
+        rich_print(f"[yellow]⚠[/yellow] Subjects skipped: {stats.subjects_skipped}")
+    if stats.errors > 0:
+        rich_print(f"[yellow]⚠[/yellow] Errors encountered: {stats.errors}")
+
 @app.command("add-experiment")
 def add_experiment(
     experiment_id: str = typer.Argument(..., help="Experiment ID"),

--- a/test_rotarod_import.py
+++ b/test_rotarod_import.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Smoke test script for rotarod import functionality."""
+
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from mus1.core.schema import Database
+from mus1.core.repository import get_repository_factory
+from mus1.core.importers.rotarod import import_rotarod_csv
+
+CSV_PATH = Path("/center1/WDMOSEQ2/llplatil/WDMOSEQ2/moseq2_workspace/statistics_summaries/rotarod_reanalysis/rotarod_attempts_long_cleaned.csv")
+
+
+def main():
+    """Run smoke test."""
+    print("=" * 60)
+    print("Rotarod Import Smoke Test")
+    print("=" * 60)
+    
+    # Create temporary project directory
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_path = Path(tmpdir) / "test_project"
+        project_path.mkdir()
+        db_path = project_path / "mus1.db"
+        
+        print(f"\n[1] Creating test database at: {db_path}")
+        db = Database(str(db_path))
+        db.create_tables()
+        print("    ✓ Database created")
+        
+        print(f"\n[2] Initializing repositories")
+        repos = get_repository_factory(db)
+        print("    ✓ Repositories initialized")
+        
+        print(f"\n[3] Importing rotarod CSV: {CSV_PATH}")
+        if not CSV_PATH.exists():
+            print(f"    ✗ CSV file not found: {CSV_PATH}")
+            return 1
+        
+        try:
+            stats = import_rotarod_csv(
+                repos,
+                csv_path=CSV_PATH,
+                assay_type="rotarod",
+            )
+            
+            print("    ✓ Import completed")
+            print(f"\n[4] Import Statistics:")
+            print(f"    - Rows processed: {stats.rows_total}")
+            print(f"    - Assay sessions created: {stats.assay_sessions_created}")
+            print(f"    - Assay measurements created: {stats.assay_measurements_created}")
+            print(f"    - Subjects created: {stats.subjects_created}")
+            print(f"    - Subjects skipped: {stats.subjects_skipped}")
+            print(f"    - Errors: {stats.errors}")
+            
+            # Verify some data was imported
+            print(f"\n[5] Verification:")
+            all_subjects = repos.subjects.find_all()
+            print(f"    - Total subjects in DB: {len(all_subjects)}")
+            
+            # Check assay sessions
+            from mus1.core.schema import AssaySessionModel
+            with db.get_session() as session:
+                session_count = session.query(AssaySessionModel).count()
+                print(f"    - Assay sessions in DB: {session_count}")
+                
+                from mus1.core.schema import AssayMeasurementModel
+                measurement_count = session.query(AssayMeasurementModel).count()
+                print(f"    - Assay measurements in DB: {measurement_count}")
+            
+            # Check a sample session
+            print(f"\n[6] Sample Data Check:")
+            with db.get_session() as session:
+                sample_session = session.query(AssaySessionModel).first()
+                if sample_session:
+                    print(f"    - Sample session ID: {sample_session.id}")
+                    print(f"    - Assay type: {sample_session.assay_type}")
+                    print(f"    - Subject ID: {sample_session.subject_id}")
+                    print(f"    - Occurred at: {sample_session.occurred_at}")
+                    
+                    sample_measurements = session.query(AssayMeasurementModel).filter(
+                        AssayMeasurementModel.assay_session_id == sample_session.id
+                    ).limit(3).all()
+                    print(f"    - Sample measurements: {len(sample_measurements)}")
+                    for m in sample_measurements:
+                        print(f"      * {m.metric}: {m.value} {m.units or ''}")
+                        if m.qc_flags_json:
+                            import json
+                            qc_flags = json.loads(m.qc_flags_json)
+                            if qc_flags:
+                                print(f"        QC flags: {qc_flags}")
+            
+            print(f"\n[7] Test Results:")
+            if stats.errors == 0 and stats.assay_sessions_created > 0:
+                print("    ✓ All checks passed!")
+                return 0
+            else:
+                print("    ⚠ Some issues detected (check stats above)")
+                return 1
+                
+        except Exception as e:
+            print(f"    ✗ Import failed with error: {e}")
+            import traceback
+            traceback.print_exc()
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for mus1."""

--- a/tests/test_moseq2_workspace_importer.py
+++ b/tests/test_moseq2_workspace_importer.py
@@ -1,0 +1,79 @@
+"""
+Smoke test for MoSeq2 workspace importer.
+"""
+
+import tempfile
+import shutil
+from pathlib import Path
+import pandas as pd
+
+from mus1.core.schema import Database
+from mus1.core.repository import get_repository_factory
+from mus1.core.importers.moseq2_workspace import import_session_index
+
+
+def test_import_smoke():
+    """Minimal smoke test for moseq2-workspace importer."""
+    # Create temporary directories
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        
+        # Create project directory with database
+        project_path = tmp_path / "test_project"
+        project_path.mkdir()
+        db_path = project_path / "mus1.db"
+        db = Database(str(db_path))
+        db.create_tables()
+        repos = get_repository_factory(db)
+        
+        # Create workspace directory
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        
+        # Create a minimal CSV file
+        csv_path = workspace_root / "session_index.csv"
+        test_data = {
+            "session_id": ["OF__262__2024-10-09"],
+            "task": ["OF"],
+            "subject_id": ["262"],
+            "recording_date": ["2024-10-09"],
+            "birthdate": ["2024-03-11"],
+            "age_days": [212],
+            "sex": ["M"],
+            "genotype": ["HET"],
+            "treatment": ["CONTROL"],
+            "arena_bucket": ["OLD"],
+            "video_path": [""],
+            "moseq2_results_h5_path": ["/some/path/results.h5"],
+        }
+        df = pd.DataFrame(test_data)
+        df.to_csv(csv_path, index=False)
+        
+        # Run import
+        stats = import_session_index(
+            repos,
+            workspace_root=workspace_root,
+            session_index_csv=csv_path,
+            check_paths_exist=False,  # Don't check paths for smoke test
+        )
+        
+        # Verify basic stats
+        assert stats.rows_total == 1
+        assert stats.subjects_upserted == 1
+        assert stats.experiments_upserted == 1
+        
+        # Verify subject was created
+        subject = repos.subjects.find_by_id("262")
+        assert subject is not None
+        assert subject.id == "262"
+        
+        # Verify experiment was created
+        experiment = repos.experiments.find_by_id("OF__262__2024-10-09")
+        assert experiment is not None
+        assert experiment.subject_id == "262"
+        assert experiment.experiment_type == "OF"
+
+
+if __name__ == "__main__":
+    test_import_smoke()
+    print("✓ Smoke test passed")


### PR DESCRIPTION
Adds generic assay session/measurement tables plus QC event and external artifact pointer tables, and relaxes video hash requirements to support path-first datasets on Chinook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dataset-first ingestion path and supporting schema for Chinook-scale workspaces.
> 
> - Adds `moseq2_workspace`, `kpms_recordings`, and `rotarod` importers that upsert `subjects/experiments/videos`, persist artifact paths, and record non-fatal QC
> - Extends DB with `assay_sessions`, `assay_measurements`, `external_artifacts`, and `qc_events`; updates repositories accordingly
> - Makes `videos.hash` optional and adjusts duplicate detection to ignore NULL hashes; `VideoFile.hash` now optional
> - Adds CLI commands: `import moseq2-workspace`, `project import-kpms-recordings`, `import-rotarod`, and a `test-kpms-import` smoke test
> - Adds planning doc for MoSeq2 workspace import and smoke tests for importers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4807083cfbd4834efef0e57c41daa4bf1fd1f2d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->