### PR TITLE
Feature/importer cli

### DIFF
--- a/src/mus1/core/importers/__init__.py
+++ b/src/mus1/core/importers/__init__.py
@@ -1,0 +1,1 @@
+"""Importers for various data sources."""

--- a/src/mus1/core/importers/moseq2_workspace.py
+++ b/src/mus1/core/importers/moseq2_workspace.py
@@ -1,0 +1,253 @@
+"""
+MoSeq2 workspace importer.
+
+Reads session_index_filtered.csv and imports subjects, experiments, external artifacts,
+and QC events into the MUS1 repository.
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Any, Optional
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import pandas as pd
+
+from ..repository import RepositoryFactory
+from ..metadata import Subject, Experiment, VideoFile, Sex, ProcessingStage, SubjectDesignation
+
+
+@dataclass
+class ImportStats:
+    """Statistics from an import operation."""
+    rows_total: int = 0
+    subjects_upserted: int = 0
+    experiments_upserted: int = 0
+    videos_upserted: int = 0
+    artifacts_added: int = 0
+    qc_events_added: int = 0
+
+
+def _as_path(value: Any) -> Optional[Path]:
+    """Convert a value to a Path if it's a non-empty string, otherwise None."""
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    return Path(value)
+
+
+def _resolve_path(path: Path, workspace_root: Path) -> Path:
+    """Resolve a path to absolute, preferring absolute paths when possible."""
+    if path.is_absolute():
+        return path
+    # Try relative to workspace_root
+    resolved = workspace_root / path
+    if resolved.exists():
+        return resolved.resolve()
+    # Return as-is if it doesn't exist (will be caught by QC check)
+    return path
+
+
+def _parse_date(date_str: Any) -> Optional[datetime]:
+    """Parse a date string to datetime."""
+    if not date_str or pd.isna(date_str):
+        return None
+    if isinstance(date_str, datetime):
+        return date_str
+    if isinstance(date_str, str):
+        date_str = date_str.strip()
+        if not date_str:
+            return None
+        try:
+            return datetime.fromisoformat(date_str)
+        except ValueError:
+            try:
+                return datetime.strptime(date_str, "%Y-%m-%d")
+            except ValueError:
+                return None
+    return None
+
+
+def _parse_sex(sex_str: Any) -> Sex:
+    """Parse sex string to Sex enum."""
+    if not sex_str or pd.isna(sex_str):
+        return Sex.UNKNOWN
+    sex_str = str(sex_str).strip().upper()
+    if sex_str == "M":
+        return Sex.MALE
+    elif sex_str == "F":
+        return Sex.FEMALE
+    else:
+        return Sex.UNKNOWN
+
+
+def import_session_index(
+    repos: RepositoryFactory,
+    *,
+    workspace_root: Path,
+    session_index_csv: Path,
+    check_paths_exist: bool = True,
+) -> ImportStats:
+    """
+    Import MoSeq2 workspace session index CSV into MUS1 repository.
+
+    Args:
+        repos: Repository factory for database operations
+        workspace_root: Root directory of the MoSeq2 workspace
+        session_index_csv: Path to session_index_filtered.csv
+        check_paths_exist: If True, create QC events for missing file paths
+
+    Returns:
+        ImportStats with counts of imported entities
+    """
+    stats = ImportStats()
+
+    # Read CSV
+    df = pd.read_csv(session_index_csv)
+    stats.rows_total = len(df)
+
+    workspace_root = Path(workspace_root).resolve()
+
+    for _, row in df.iterrows():
+        # Extract subject information
+        subject_id = str(row.get("subject_id", "")).strip()
+        if not subject_id:
+            continue  # Skip rows without subject_id
+
+        # Parse subject fields
+        sex = _parse_sex(row.get("sex"))
+        genotype = str(row.get("genotype", "")).strip() or None
+        birthdate = _parse_date(row.get("birthdate"))
+
+        # Create/upsert subject
+        subject = Subject(
+            id=subject_id,
+            colony_id=None,  # No colony association from CSV
+            sex=sex,
+            designation=SubjectDesignation.EXPERIMENTAL,
+            birth_date=birthdate,
+            individual_genotype=genotype,
+            individual_treatment=str(row.get("treatment", "")).strip() or None,
+        )
+        repos.subjects.save(subject)
+        stats.subjects_upserted += 1
+
+        # Extract experiment information
+        session_id = str(row.get("session_id", "")).strip()
+        if not session_id:
+            session_id = f"{subject_id}_{row.get('recording_date', 'unknown')}"
+
+        task = str(row.get("task", "")).strip() or "unknown"
+        recording_date = _parse_date(row.get("recording_date"))
+        if not recording_date:
+            recording_date = datetime.now()  # Fallback
+
+        # Create/upsert experiment
+        experiment = Experiment(
+            id=session_id,
+            subject_id=subject_id,
+            experiment_type=task,
+            date_recorded=recording_date,
+            processing_stage=ProcessingStage.RECORDED,  # Assume recorded since we have data
+        )
+        repos.experiments.save(experiment)
+        stats.experiments_upserted += 1
+
+        # Handle video path
+        video_path = _as_path(row.get("video_path"))
+        if video_path:
+            video_path = _resolve_path(video_path, workspace_root)
+            # Save video (path-only, no hash)
+            repos.videos.save(VideoFile(path=video_path, hash=None))
+            stats.videos_upserted += 1
+            # Link video to experiment
+            repos.experiments.add_video_to_experiment_by_path(experiment.id, video_path)
+
+            # Store as external artifact
+            repos.external_artifacts.add(
+                kind="video_path",
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path=str(video_path),
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+            # Check if video exists
+            if check_paths_exist and not video_path.exists():
+                repos.qc_events.add(
+                    scope="artifact",
+                    code="MISSING_PATH",
+                    subject_id=subject_id,
+                    experiment_id=experiment.id,
+                    details={"kind": "video_path", "path": str(video_path)},
+                )
+                stats.qc_events_added += 1
+
+        # Artifact columns to index directly
+        artifact_cols = [
+            "dlc_csv_path",
+            "moseq2_results_h5_path",
+            "moseq2_results_yaml_path",
+            "moseq2_metadata_path",
+            "moseq2_identifier_path",
+            "syllable_stats_path",
+            "syllable_h5_path",
+            "kpms_syllable_stats_path",
+        ]
+
+        for col in artifact_cols:
+            p = _as_path(row.get(col))
+            if not p:
+                continue
+
+            p = _resolve_path(p, workspace_root)
+
+            # Store as external artifact
+            repos.external_artifacts.add(
+                kind=col,
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path=str(p),
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+            # Check if path exists
+            if check_paths_exist and not p.exists():
+                repos.qc_events.add(
+                    scope="artifact",
+                    code="MISSING_PATH",
+                    subject_id=subject_id,
+                    experiment_id=experiment.id,
+                    details={"kind": col, "path": str(p)},
+                )
+                stats.qc_events_added += 1
+
+        # Store scalar identifiers as meta on an artifact record
+        identifiers: Dict[str, Any] = {}
+        for k in (
+            "syllable_uuid",
+            "kpms_recording_id",
+            "moseq2_session_name",
+            "arena_bucket",
+            "moseq2_source_filename",
+        ):
+            v = str(row.get(k, "")).strip()
+            if v:
+                identifiers[k] = v
+
+        if identifiers:
+            repos.external_artifacts.add(
+                kind="identifiers",
+                experiment_id=experiment.id,
+                subject_id=subject_id,
+                path="",  # No file path for identifiers
+                payload_json=json.dumps(identifiers),  # Store as JSON string
+                meta={"source": "session_index_filtered.csv"},
+            )
+            stats.artifacts_added += 1
+
+    return stats

--- a/src/mus1/core/repository.py
+++ b/src/mus1/core/repository.py
@@ -14,6 +14,7 @@ from .schema import (
     Database, SubjectModel, ExperimentModel, VideoModel,
     WorkerModel, ScanTargetModel, ProjectModel, ColonyModel,
     AssaySessionModel, AssayMeasurementModel,
+    ExternalArtifactModel, QCEventModel,
     TrackedObjectModel, BodyPartModel, TreatmentModel, GenotypeModel,
     subject_to_model, model_to_subject,
     experiment_to_model, model_to_experiment,
@@ -455,6 +456,72 @@ class AssayMeasurementRepository(BaseRepository):
             session.commit()
             return int(row.id)
 
+
+class ExternalArtifactRepository(BaseRepository):
+    """Repository for artifact pointers (path-first)."""
+
+    def add(
+        self,
+        *,
+        kind: str,
+        path: str,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+        content_sha256: Optional[str] = None,
+        payload_json: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Add an external artifact and return its integer ID."""
+        from datetime import datetime
+        from .schema import ExternalArtifactModel
+        with self._get_session() as session:
+            row = ExternalArtifactModel(
+                kind=kind,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                path=path,
+                content_sha256=content_sha256,
+                payload_json=payload_json,
+                meta_json=json.dumps(meta or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
+
+class QCEventRepository(BaseRepository):
+    """Repository for non-fatal QC events."""
+
+    def add(
+        self,
+        *,
+        scope: str,
+        code: str,
+        details: Optional[Dict[str, Any]] = None,
+        subject_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        assay_session_id: Optional[int] = None,
+    ) -> int:
+        """Add a QC event and return its integer ID."""
+        from datetime import datetime
+        from .schema import QCEventModel
+        with self._get_session() as session:
+            row = QCEventModel(
+                scope=scope,
+                code=code,
+                subject_id=subject_id,
+                experiment_id=experiment_id,
+                assay_session_id=assay_session_id,
+                details_json=json.dumps(details or {}),
+                created_at=datetime.utcnow(),
+            )
+            session.add(row)
+            session.commit()
+            return int(row.id)
+
 class WorkerRepository(BaseRepository):
     """Repository for worker operations."""
 
@@ -875,6 +942,8 @@ class RepositoryFactory:
         # Dataset-first extensions
         self._assay_sessions: Optional[AssaySessionRepository] = None
         self._assay_measurements: Optional[AssayMeasurementRepository] = None
+        self._external_artifacts: Optional[ExternalArtifactRepository] = None
+        self._qc_events: Optional[QCEventRepository] = None
         # Metadata repositories
         self._tracked_objects: Optional[TrackedObjectRepository] = None
         self._body_parts: Optional[BodyPartRepository] = None
@@ -934,6 +1003,18 @@ class RepositoryFactory:
         if self._assay_measurements is None:
             self._assay_measurements = AssayMeasurementRepository(self.db)
         return self._assay_measurements
+
+    @property
+    def external_artifacts(self) -> ExternalArtifactRepository:
+        if self._external_artifacts is None:
+            self._external_artifacts = ExternalArtifactRepository(self.db)
+        return self._external_artifacts
+
+    @property
+    def qc_events(self) -> QCEventRepository:
+        if self._qc_events is None:
+            self._qc_events = QCEventRepository(self.db)
+        return self._qc_events
 
     @property
 # Removed: scan_targets() method (part of scan target functionality)

--- a/src/mus1/core/simple_cli.py
+++ b/src/mus1/core/simple_cli.py
@@ -42,6 +42,10 @@ app.add_typer(lab_app, name="lab")
 project_app = typer.Typer(help="Project management commands")
 app.add_typer(project_app, name="project")
 
+# Import subcommand group
+import_app = typer.Typer(help="Dataset import commands")
+app.add_typer(import_app, name="import")
+
 # ===========================================
 # CORE COMMANDS
 # ===========================================
@@ -284,6 +288,61 @@ def project_status(
     rich_print(f"[bold]Subjects:[/bold] {stats['subjects']}")
     rich_print(f"[bold]Experiments:[/bold] {stats['experiments']}")
     rich_print(f"[bold]Videos:[/bold] {stats['videos']}")
+
+# ===========================================
+# IMPORT COMMANDS
+# ===========================================
+
+@import_app.command("moseq2-workspace")
+def import_moseq2_workspace(
+    project_path: Path = typer.Option(..., help="Target MUS1 project directory (contains mus1.db)"),
+    workspace_root: Path = typer.Option(..., help="MoSeq2 workspace root"),
+    index_csv: Path = typer.Option(
+        None,
+        help="Compiled session index CSV (defaults to ml_tracking_metadata_model/index/session_index_filtered.csv under workspace_root)",
+    ),
+    check_paths_exist: bool = typer.Option(True, help="Record QC events for missing paths"),
+):
+    """Import MoSeq2 workspace session index into a MUS1 project DB (path-only; non-fatal QC)."""
+    from .schema import Database
+    from .repository import get_repository_factory
+    from .importers.moseq2_workspace import import_session_index
+
+    if not project_path.exists():
+        rich_print(f"[red]✗[/red] Project path does not exist: {project_path}")
+        raise typer.Exit(1)
+
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No mus1.db found at: {db_path}")
+        rich_print("[blue]ℹ[/blue] Create one with: mus1 project init \"<name>\" --path <project_path>")
+        raise typer.Exit(1)
+
+    if index_csv is None:
+        index_csv = workspace_root / "ml_tracking_metadata_model" / "index" / "session_index_filtered.csv"
+
+    if not index_csv.exists():
+        rich_print(f"[red]✗[/red] Index CSV not found: {index_csv}")
+        raise typer.Exit(1)
+
+    db = Database(str(db_path))
+    db.create_tables()
+    repos = get_repository_factory(db)
+
+    stats = import_session_index(
+        repos,
+        workspace_root=workspace_root,
+        session_index_csv=index_csv,
+        check_paths_exist=check_paths_exist,
+    )
+
+    rich_print("[green]✓[/green] Import complete")
+    rich_print(f"[blue]ℹ[/blue] Rows: {stats.rows_total}")
+    rich_print(f"[blue]ℹ[/blue] Subjects upserted: {stats.subjects_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Experiments upserted: {stats.experiments_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Videos upserted: {stats.videos_upserted}")
+    rich_print(f"[blue]ℹ[/blue] Artifacts added: {stats.artifacts_added}")
+    rich_print(f"[blue]ℹ[/blue] QC events added: {stats.qc_events_added}")
 
 # ===========================================
 # DATA MANAGEMENT

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for mus1."""

--- a/tests/test_moseq2_workspace_importer.py
+++ b/tests/test_moseq2_workspace_importer.py
@@ -1,0 +1,79 @@
+"""
+Smoke test for MoSeq2 workspace importer.
+"""
+
+import tempfile
+import shutil
+from pathlib import Path
+import pandas as pd
+
+from mus1.core.schema import Database
+from mus1.core.repository import get_repository_factory
+from mus1.core.importers.moseq2_workspace import import_session_index
+
+
+def test_import_smoke():
+    """Minimal smoke test for moseq2-workspace importer."""
+    # Create temporary directories
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        
+        # Create project directory with database
+        project_path = tmp_path / "test_project"
+        project_path.mkdir()
+        db_path = project_path / "mus1.db"
+        db = Database(str(db_path))
+        db.create_tables()
+        repos = get_repository_factory(db)
+        
+        # Create workspace directory
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        
+        # Create a minimal CSV file
+        csv_path = workspace_root / "session_index.csv"
+        test_data = {
+            "session_id": ["OF__262__2024-10-09"],
+            "task": ["OF"],
+            "subject_id": ["262"],
+            "recording_date": ["2024-10-09"],
+            "birthdate": ["2024-03-11"],
+            "age_days": [212],
+            "sex": ["M"],
+            "genotype": ["HET"],
+            "treatment": ["CONTROL"],
+            "arena_bucket": ["OLD"],
+            "video_path": [""],
+            "moseq2_results_h5_path": ["/some/path/results.h5"],
+        }
+        df = pd.DataFrame(test_data)
+        df.to_csv(csv_path, index=False)
+        
+        # Run import
+        stats = import_session_index(
+            repos,
+            workspace_root=workspace_root,
+            session_index_csv=csv_path,
+            check_paths_exist=False,  # Don't check paths for smoke test
+        )
+        
+        # Verify basic stats
+        assert stats.rows_total == 1
+        assert stats.subjects_upserted == 1
+        assert stats.experiments_upserted == 1
+        
+        # Verify subject was created
+        subject = repos.subjects.find_by_id("262")
+        assert subject is not None
+        assert subject.id == "262"
+        
+        # Verify experiment was created
+        experiment = repos.experiments.find_by_id("OF__262__2024-10-09")
+        assert experiment is not None
+        assert experiment.subject_id == "262"
+        assert experiment.experiment_type == "OF"
+
+
+if __name__ == "__main__":
+    test_import_smoke()
+    print("✓ Smoke test passed")


### PR DESCRIPTION
## Summary

This PR adds a new CLI command `mus1 import moseq2-workspace` that imports MoSeq2 workspace session index data into a MUS1 project database.

## Features
- Reads `session_index_filtered.csv` and imports subjects, experiments, external artifacts, and QC events
- Stores file paths only (no video copying) - prefers absolute paths when possible
- Creates QC events for missing file paths when `--check-paths-exist` is enabled

## Smoke Run Example
mus1 import moseq2-workspace \
  --project-path /path/to/project \
  --workspace-root /center1/WDMOSEQ2/llplatil/WDMOSEQ2/moseq2_workspace \
  --index-csv /center1/WDMOSEQ2/llplatil/WDMOSEQ2/moseq2_workspace/ml_tracking_metadata_model/index/session_index_filtered.csv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a path-first MoSeq2 workspace importer and CLI to load session metadata into MUS1, creating core records and indexing artifact paths with optional QC checks.
> 
> - Adds `importers/moseq2_workspace.py` with `import_session_index` to upsert `subjects`, `experiments`, associate `videos`, and add `external_artifacts` and `qc_events` from `session_index_filtered.csv`
> - Resolves relative paths against `workspace_root`; records path-only artifacts and flags missing paths via QC when `check_paths_exist` is enabled
> - Extends repository with `ExternalArtifactRepository` and `QCEventRepository`, exposed via `RepositoryFactory`
> - Adds CLI command `mus1 import moseq2-workspace` to run the import and print stats
> - Adds a smoke test `tests/test_moseq2_workspace_importer.py` covering basic import behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bb9fbc408502fc8c1f2755f98530e74b6dfa38d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->