### PR TITLE
Add rotarod CSV import functionality

### DIFF
--- a/src/mus1/core/importers/__init__.py
+++ b/src/mus1/core/importers/__init__.py
@@ -1,0 +1,1 @@
+"""Importers for various data sources."""

--- a/src/mus1/core/importers/rotarod.py
+++ b/src/mus1/core/importers/rotarod.py
@@ -1,0 +1,269 @@
+"""Importer for rotarod assay CSV data."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from ..metadata import AssaySession, AssayMeasurement, Subject, Sex, SubjectDesignation
+from ..repository import RepositoryFactory
+
+
+@dataclass(frozen=True)
+class RotarodImportStats:
+    """Statistics from rotarod import."""
+    rows_total: int
+    assay_sessions_created: int
+    assay_measurements_created: int
+    subjects_created: int
+    subjects_skipped: int
+    errors: int
+
+
+def _parse_date(value: str) -> Optional[datetime]:
+    """Parse date string to datetime."""
+    if not value or not value.strip():
+        return None
+    try:
+        # Try YYYY-MM-DD format
+        return datetime.strptime(value.strip(), "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _normalize_tag_number(tag: str) -> str:
+    """Normalize tag number (remove leading zeros)."""
+    try:
+        return str(int(tag.strip()))
+    except (ValueError, AttributeError):
+        return str(tag).strip()
+
+
+def _ensure_subject_exists(
+    repos: RepositoryFactory,
+    tag_number: str,
+    sex: Optional[str] = None,
+    genotype: Optional[str] = None,
+) -> Tuple[Optional[Subject], bool]:
+    """
+    Ensure subject exists, creating if necessary.
+    
+    Returns:
+        Tuple of (subject, was_created) where was_created is True if subject was just created
+    """
+    tag_normalized = _normalize_tag_number(tag_number)
+    
+    # Try to find existing subject
+    subject = repos.subjects.find_by_id(tag_normalized)
+    if subject:
+        return subject, False
+    
+    # Create new subject if not found
+    # Map sex string to enum
+    sex_enum = Sex.UNKNOWN
+    if sex:
+        sex_upper = sex.strip().upper()
+        if sex_upper == "M":
+            sex_enum = Sex.MALE
+        elif sex_upper == "F":
+            sex_enum = Sex.FEMALE
+    
+    subject = Subject(
+        id=tag_normalized,
+        colony_id=None,
+        sex=sex_enum,
+        designation=SubjectDesignation.EXPERIMENTAL,
+        individual_genotype=genotype.strip() if genotype else None,
+    )
+    
+    try:
+        created_subject = repos.subjects.save(subject)
+        return created_subject, True
+    except Exception:
+        # Subject creation failed (e.g., constraint violation)
+        return None, False
+
+
+def import_rotarod_csv(
+    repos: RepositoryFactory,
+    csv_path: Path,
+    assay_type: str = "rotarod",
+) -> RotarodImportStats:
+    """
+    Import rotarod assay data from CSV.
+    
+    Creates assay_sessions per (tag_number, session_id) and assay_measurements
+    for each row with metrics like time_sec, speed_rpm, attempt.
+    
+    Args:
+        repos: Repository factory for database operations
+        csv_path: Path to rotarod CSV file
+        assay_type: Type identifier for assay sessions (default: "rotarod")
+    
+    Returns:
+        Import statistics
+    """
+    rows_total = 0
+    assay_sessions_created = 0
+    assay_measurements_created = 0
+    subjects_created = 0
+    subjects_skipped = 0
+    errors = 0
+    
+    # Track created sessions by (tag_number, session_id) to avoid duplicates
+    session_cache: Dict[Tuple[str, str], int] = {}
+    
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+    
+    with open(csv_path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        
+        for row in reader:
+            rows_total += 1
+            
+            try:
+                tag_number = row.get("tag_number", "").strip()
+                session_id = row.get("session_id", "").strip()
+                
+                if not tag_number or not session_id:
+                    errors += 1
+                    continue
+                
+                # Ensure subject exists
+                sex = row.get("sex_final", "").strip()
+                genotype = row.get("genotype_final", "").strip()
+                subject, was_created = _ensure_subject_exists(repos, tag_number, sex, genotype)
+                
+                if not subject:
+                    subjects_skipped += 1
+                    errors += 1
+                    continue
+                
+                if was_created:
+                    subjects_created += 1
+                
+                # Check if we already created this session
+                # Use normalized tag_number for consistency
+                tag_normalized = _normalize_tag_number(tag_number)
+                session_key = (tag_normalized, session_id)
+                assay_session_id = session_cache.get(session_key)
+                
+                if assay_session_id is None:
+                    # Create new assay session
+                    test_date_str = row.get("test_date", "").strip()
+                    occurred_at = _parse_date(test_date_str)
+                    
+                    # Collect metadata for session
+                    session_meta: Dict[str, Any] = {
+                        "source_file": row.get("source_file", "").strip(),
+                        "session_index": row.get("session_index", "").strip(),
+                        "genotype_final": genotype,
+                        "sex_final": sex,
+                        "birthdate_final": row.get("birthdate_final", "").strip(),
+                        "treatment_roster": row.get("treatment_roster", "").strip(),
+                        "age_days": row.get("age_days", "").strip(),
+                    }
+                    
+                    assay_session = AssaySession(
+                        assay_type=assay_type,
+                        subject_id=subject.id,
+                        occurred_at=occurred_at,
+                        experiment_id=None,  # No experiment linkage for rotarod
+                        source_path=csv_path,
+                        meta=session_meta,
+                    )
+                    
+                    assay_session_id = repos.assay_sessions.create(assay_session)
+                    session_cache[session_key] = assay_session_id
+                    assay_sessions_created += 1
+                
+                # Create measurements for this row
+                # Measurement 1: time_sec
+                time_sec_str = row.get("time_sec", "").strip()
+                if time_sec_str:
+                    try:
+                        time_value = float(time_sec_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="time_sec",
+                            value=time_value,
+                            units="seconds",
+                            qc_flags=qc_flags,
+                            details={
+                                "attempt": row.get("attempt", "").strip(),
+                                "speed_rpm": row.get("speed_rpm", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid time_sec
+                
+                # Measurement 2: speed_rpm
+                speed_rpm_str = row.get("speed_rpm", "").strip()
+                if speed_rpm_str:
+                    try:
+                        speed_value = float(speed_rpm_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="speed_rpm",
+                            value=speed_value,
+                            units="rpm",
+                            qc_flags=qc_flags,
+                            details={
+                                "attempt": row.get("attempt", "").strip(),
+                                "time_sec": row.get("time_sec", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid speed_rpm
+                
+                # Measurement 3: attempt (as a metric)
+                attempt_str = row.get("attempt", "").strip()
+                if attempt_str:
+                    try:
+                        attempt_value = float(attempt_str)
+                        exclude_reason = row.get("exclude_reason", "").strip()
+                        qc_flags = [exclude_reason] if exclude_reason else []
+                        
+                        measurement = AssayMeasurement(
+                            assay_session_id=assay_session_id,
+                            metric="attempt",
+                            value=attempt_value,
+                            units=None,
+                            qc_flags=qc_flags,
+                            details={
+                                "time_sec": row.get("time_sec", "").strip(),
+                                "speed_rpm": row.get("speed_rpm", "").strip(),
+                            },
+                        )
+                        repos.assay_measurements.add(measurement)
+                        assay_measurements_created += 1
+                    except (ValueError, TypeError):
+                        pass  # Skip invalid attempt
+                
+            except Exception as e:
+                errors += 1
+                # Continue processing other rows
+                continue
+    
+    return RotarodImportStats(
+        rows_total=rows_total,
+        assay_sessions_created=assay_sessions_created,
+        assay_measurements_created=assay_measurements_created,
+        subjects_created=subjects_created,
+        subjects_skipped=subjects_skipped,
+        errors=errors,
+    )

--- a/src/mus1/core/simple_cli.py
+++ b/src/mus1/core/simple_cli.py
@@ -349,6 +349,51 @@ def add_subject(
     if subject.genotype:
         rich_print(f"[blue]ℹ[/blue] Genotype: {subject.genotype}")
 
+@app.command("import-rotarod")
+def import_rotarod(
+    project_path: Path = typer.Option(..., help="Target MUS1 project directory (contains mus1.db)"),
+    csv_path: Path = typer.Option(..., help="Path to rotarod CSV file"),
+    assay_type: str = typer.Option("rotarod", help="Assay type identifier"),
+):
+    """Import rotarod assay data from CSV into a MUS1 project DB."""
+    from .schema import Database
+    from .repository import get_repository_factory
+    from .importers.rotarod import import_rotarod_csv
+
+    if not project_path.exists():
+        rich_print(f"[red]✗[/red] Project path does not exist: {project_path}")
+        raise typer.Exit(1)
+
+    db_path = project_path / "mus1.db"
+    if not db_path.exists():
+        rich_print(f"[red]✗[/red] No mus1.db found at: {db_path}")
+        rich_print("[blue]ℹ[/blue] Create one with: mus1 project init \"<name>\" --path <project_path>")
+        raise typer.Exit(1)
+
+    if not csv_path.exists():
+        rich_print(f"[red]✗[/red] CSV file not found: {csv_path}")
+        raise typer.Exit(1)
+
+    db = Database(str(db_path))
+    db.create_tables()
+    repos = get_repository_factory(db)
+
+    stats = import_rotarod_csv(
+        repos,
+        csv_path=csv_path,
+        assay_type=assay_type,
+    )
+
+    rich_print("[green]✓[/green] Import complete")
+    rich_print(f"[blue]ℹ[/blue] Rows processed: {stats.rows_total}")
+    rich_print(f"[blue]ℹ[/blue] Assay sessions created: {stats.assay_sessions_created}")
+    rich_print(f"[blue]ℹ[/blue] Assay measurements created: {stats.assay_measurements_created}")
+    rich_print(f"[blue]ℹ[/blue] Subjects created: {stats.subjects_created}")
+    if stats.subjects_skipped > 0:
+        rich_print(f"[yellow]⚠[/yellow] Subjects skipped: {stats.subjects_skipped}")
+    if stats.errors > 0:
+        rich_print(f"[yellow]⚠[/yellow] Errors encountered: {stats.errors}")
+
 @app.command("add-experiment")
 def add_experiment(
     experiment_id: str = typer.Argument(..., help="Experiment ID"),

--- a/test_rotarod_import.py
+++ b/test_rotarod_import.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Smoke test script for rotarod import functionality."""
+
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from mus1.core.schema import Database
+from mus1.core.repository import get_repository_factory
+from mus1.core.importers.rotarod import import_rotarod_csv
+
+CSV_PATH = Path("/center1/WDMOSEQ2/llplatil/WDMOSEQ2/moseq2_workspace/statistics_summaries/rotarod_reanalysis/rotarod_attempts_long_cleaned.csv")
+
+
+def main():
+    """Run smoke test."""
+    print("=" * 60)
+    print("Rotarod Import Smoke Test")
+    print("=" * 60)
+    
+    # Create temporary project directory
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_path = Path(tmpdir) / "test_project"
+        project_path.mkdir()
+        db_path = project_path / "mus1.db"
+        
+        print(f"\n[1] Creating test database at: {db_path}")
+        db = Database(str(db_path))
+        db.create_tables()
+        print("    ✓ Database created")
+        
+        print(f"\n[2] Initializing repositories")
+        repos = get_repository_factory(db)
+        print("    ✓ Repositories initialized")
+        
+        print(f"\n[3] Importing rotarod CSV: {CSV_PATH}")
+        if not CSV_PATH.exists():
+            print(f"    ✗ CSV file not found: {CSV_PATH}")
+            return 1
+        
+        try:
+            stats = import_rotarod_csv(
+                repos,
+                csv_path=CSV_PATH,
+                assay_type="rotarod",
+            )
+            
+            print("    ✓ Import completed")
+            print(f"\n[4] Import Statistics:")
+            print(f"    - Rows processed: {stats.rows_total}")
+            print(f"    - Assay sessions created: {stats.assay_sessions_created}")
+            print(f"    - Assay measurements created: {stats.assay_measurements_created}")
+            print(f"    - Subjects created: {stats.subjects_created}")
+            print(f"    - Subjects skipped: {stats.subjects_skipped}")
+            print(f"    - Errors: {stats.errors}")
+            
+            # Verify some data was imported
+            print(f"\n[5] Verification:")
+            all_subjects = repos.subjects.find_all()
+            print(f"    - Total subjects in DB: {len(all_subjects)}")
+            
+            # Check assay sessions
+            from mus1.core.schema import AssaySessionModel
+            with db.get_session() as session:
+                session_count = session.query(AssaySessionModel).count()
+                print(f"    - Assay sessions in DB: {session_count}")
+                
+                from mus1.core.schema import AssayMeasurementModel
+                measurement_count = session.query(AssayMeasurementModel).count()
+                print(f"    - Assay measurements in DB: {measurement_count}")
+            
+            # Check a sample session
+            print(f"\n[6] Sample Data Check:")
+            with db.get_session() as session:
+                sample_session = session.query(AssaySessionModel).first()
+                if sample_session:
+                    print(f"    - Sample session ID: {sample_session.id}")
+                    print(f"    - Assay type: {sample_session.assay_type}")
+                    print(f"    - Subject ID: {sample_session.subject_id}")
+                    print(f"    - Occurred at: {sample_session.occurred_at}")
+                    
+                    sample_measurements = session.query(AssayMeasurementModel).filter(
+                        AssayMeasurementModel.assay_session_id == sample_session.id
+                    ).limit(3).all()
+                    print(f"    - Sample measurements: {len(sample_measurements)}")
+                    for m in sample_measurements:
+                        print(f"      * {m.metric}: {m.value} {m.units or ''}")
+                        if m.qc_flags_json:
+                            import json
+                            qc_flags = json.loads(m.qc_flags_json)
+                            if qc_flags:
+                                print(f"        QC flags: {qc_flags}")
+            
+            print(f"\n[7] Test Results:")
+            if stats.errors == 0 and stats.assay_sessions_created > 0:
+                print("    ✓ All checks passed!")
+                return 0
+            else:
+                print("    ⚠ Some issues detected (check stats above)")
+                return 1
+                
+        except Exception as e:
+            print(f"    ✗ Import failed with error: {e}")
+            import traceback
+            traceback.print_exc()
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Create importers/rotarod.py with import_rotarod_csv function
- Creates assay_sessions per (tag_number, session_id)
- Creates assay_measurements for time_sec, speed_rpm, attempt metrics
- Preserves exclude_reason in qc_flags
- Auto-creates subjects if they don't exist
- Add CLI command: mus1 import-rotarod
- Add smoke test script: test_rotarod_import.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces rotarod CSV import capability and a CLI entrypoint to load data into a project database.
> 
> - Adds `importers/rotarod.py` to parse CSV rows, normalize `tag_number`, auto-create `Subject`s, and create `AssaySession`s per `(tag_number, session_id)` with session metadata (e.g., `test_date`, `genotype_final`, `sex_final`)
> - Persists `AssayMeasurement`s for `time_sec`, `speed_rpm`, and `attempt`, including `exclude_reason` in `qc_flags`
> - New CLI `mus1 import-rotarod` to run the import against an existing `mus1.db`, with summary stats output
> - Adds `importers/__init__.py` and a smoke test `test_rotarod_import.py` for basic end-to-end verification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7751cd665fa691d878442994080210971080814f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->